### PR TITLE
feat: add user-defined forecast period to all methods

### DIFF
--- a/forecast/forecast.py
+++ b/forecast/forecast.py
@@ -5,6 +5,7 @@
 import typing
 import warnings
 from decimal import Decimal
+from itertools import cycle
 
 
 class Forecast:
@@ -40,27 +41,42 @@ class Forecast:
 
 		return self
 
-	def percent_over_previous_period(self, percent: Decimal) -> "Forecast":
+	def percent_over_previous_period(self, percent: Decimal, n: int | None = None) -> "Forecast":
 		"""
 		Applies the given percent to the items in the most recent provided data to generate the
 		forecasted data.
+
+		:param percent: rate applied to the previous period's data to create the forecasted values
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		if not isinstance(percent, Decimal):
 			raise TypeError("Percent must be of type Decimal.")
 
+		n = n or len(self.data[-1])
+		previous_period = cycle(self.data[-1])
 		self.forecast = [
-			period * (self.__dvone + (percent / self.__dvhundred)) if percent else self.__dvzero
-			for period in self.data[-1]
+			next(previous_period) * (self.__dvone + (percent / self.__dvhundred)) for _ in range(n)
 		]
 
 		return self
 
-	def calculated_percent_over_previous_period(self, periods: int = 0) -> "Forecast":
+	def calculated_percent_over_previous_period(
+		self, periods: int = 0, n: int | None = None
+	) -> "Forecast":
 		"""
 		Calculates the percent change of the most recent provided data over the second most recent
-		provided data and applies that rate to generate the forecast. By default, it uses all
-		periods in the data lists for the calculation, but if `periods` is provided, then it only
-		uses that many items from the end of each data list to calculate the growth rate.
+		provided data and applies that rate to the values starting with the most recent provided
+		data to generate the forecast. By default, it uses all periods in the data lists for the
+		calculation, but if `periods` is provided, then it only uses that many items from the end
+		of each data list to calculate the growth rate. If `n` is given and requires more periods
+		to forecast than are in the recent data, it will cycle over the values of the most recent
+		provided data as needed.
+
+		:param periods: the number of periods to use to calculate the percent change. If 0, uses
+		all periods in provided data
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		if len(self.data) < 2:
 			raise Exception(
@@ -81,30 +97,46 @@ class Forecast:
 		n_minus_2_data = sum(self.data[-2][-periods:])
 		n_minus_1_data = sum(self.data[-1][-periods:])
 		percent = ((n_minus_1_data / n_minus_2_data) - self.__dvone) * self.__dvhundred
-		self.forecast = [n * (self.__dvone + (percent / self.__dvhundred)) for n in self.data[-1]]
+
+		n = n or len(self.data[-1])
+		previous_period = cycle(self.data[-1])
+		self.forecast = [
+			next(previous_period) * (self.__dvone + (percent / self.__dvhundred)) for _ in range(n)
+		]
 
 		return self
 
-	def previous_period_to_current_period(self) -> "Forecast":
+	def previous_period_to_current_period(self, n: int | None = None) -> "Forecast":
 		"""
 		Generates the forecasted data by setting it equal to the most recent provided data with
-		no changes.
+		no changes. If `n` is given and requires more periods to forecast than are in the recent
+		data, it will cycle over the values of the most recent provided data as needed.
+
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
-		self.forecast = self.data[-1]
+		n = n or len(self.data[-1])
+		previous_period = cycle(self.data[-1])
+		self.forecast = [next(previous_period) for _ in range(n)]
 
 		return self
 
-	def moving_average(self, periods: int) -> "Forecast":
+	def moving_average(self, periods: int, n: int | None = None) -> "Forecast":
 		"""
 		Generates the forecasted data by calculating a moving average of the prior number of
 		`periods` in the provided data.
+
+		:param periods: the number of periods to include in the averaging calculation
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		_data = self.__flat_data if periods > len(self.data[-1]) else self.data[-1]
 		if (periods - 1) > len(self.__flat_data):
 			raise Exception("Cannot average more periods than existing in data.")
 
+		n = n or len(self.data[-1])
 		moving_average = _data[-periods:]
-		for i in range(len(self.data[-1])):
+		for i in range(n):
 			moving_average.append(mean(moving_average[-periods:]))
 
 		# Remove the historical data needed for the first several forecast period calcs
@@ -113,46 +145,62 @@ class Forecast:
 
 		return self
 
-	def linear_approximation(self, periods: int) -> "Forecast":
+	def linear_approximation(self, periods: int, n: int | None = None) -> "Forecast":
 		"""
-		Extrapolates the slope, or trend line, from the most recent item in the provided data to
-		the item that's `periods` back from it, then applies that trend to the most recent
-		provided data item onwards to generate the forecast.
+		Extrapolates the slope, or trend line, from the most recent value in the provided data to
+		the value that is `periods` back from it, then applies that trend to the most recent
+		provided data value onwards to generate the forecast.
+
+		:param periods: the number of periods back to get the value to use with the most recent
+		value in the provided data to calculate the slope, or trend line, to use to generate the
+		forecast
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		_data = self.__flat_data if periods >= len(self.data[-1]) else self.data[-1]
 		if (periods - 1) > len(_data):
 			raise Exception(
 				"Cannot calculate the linear approximation slope for more periods than existing in data."
 			)
+
+		n = n or len(self.data[-1])
 		slope = (_data[-1] - _data[-periods - 1]) / Decimal(periods)
-		self.forecast = [_data[-1] + (slope * Decimal(i + 1)) for i in range(len(self.data[-1]))]
+		self.forecast = [_data[-1] + (slope * Decimal(i + 1)) for i in range(n)]
 
 		return self
 
-	def least_squares_regression(self, periods: int) -> "Forecast":
+	def least_squares_regression(self, periods: int, n: int | None = None) -> "Forecast":
 		"""
 		Finds a line of best fit via the Least Squares Regression method using the given `periods`
 		of provided data. It applies the calculated slope (m) and intercept (b) to generate the
 		forecasted values with the formula y = mx + b.
+
+		:param periods: the number of periods of provided data to find the line of best fit
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		x = [Decimal(i) for i in range(1, periods + 1)]
 		_data = self.__flat_data if periods > len(self.data[-1]) else self.data[-1]
 		if (periods - 1) > len(_data):
 			raise Exception("Cannot determine line of best fit using more periods than existing in data.")
-		y = _data[-periods:]
 
+		y = _data[-periods:]
+		n = n or len(self.data[-1])
 		slope, intercept, _, _, _ = linregress(x, y)
-		self.forecast = [
-			(Decimal(i) * slope) + intercept for i in range(periods + 1, periods + 1 + len(self.data[-1]))
-		]
+		self.forecast = [(Decimal(i) * slope) + intercept for i in range(periods + 1, periods + 1 + n)]
 
 		return self
 
-	def second_degree_approximation(self, periods: int) -> "Forecast":
+	def second_degree_approximation(self, periods: int, n: int | None = None) -> "Forecast":
 		"""
 		Fits a second-degree polynomial of the form y = a + bx + cx^2 using the given `periods` of
 		provided data as inputs. It applies the calculated coefficients (a, b, and c) to generate
 		the forecasted values.
+
+		:param periods: the number of periods of provided data to find the second-degree
+		polynomial's coefficients
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		x = [Decimal(i) for i in range(1, periods + 1)]
 		_data = self.__flat_data if periods > len(self.data[-1]) else self.data[-1]
@@ -161,18 +209,24 @@ class Forecast:
 				"Cannot determine second-degree polynomial trend using more periods than existing in data."
 			)
 		y = _data[-periods:]
+		n = n or len(self.data[-1])
 		c, b, a = polyfit(x, y, deg=2)
 		self.forecast = [
-			a + (b * Decimal(i)) + (c * (Decimal(i) ** 2))
-			for i in range(periods + 1, periods + 1 + len(self.data[-1]))
+			a + (b * Decimal(i)) + (c * (Decimal(i) ** 2)) for i in range(periods + 1, periods + 1 + n)
 		]
 
 		return self
 
-	def flexible_method(self, percent: Decimal, periods: int) -> "Forecast":
+	def flexible_method(self, percent: Decimal, periods: int, n: int | None = None) -> "Forecast":
 		"""
 		Applies the given `percent` growth rate to provided data, starting with `periods` most
 		recent value.
+
+		:param percent: rate applied to generate the forecasted values
+		:param periods: the number of periods back from the end of the provided data to use as the
+		starting point for the forecast
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		# Confirm percent is of Decimal type
 		if not isinstance(percent, Decimal):
@@ -183,7 +237,8 @@ class Forecast:
 			raise Exception("Cannot build forecast off a period farther back from what's in existing data.")
 
 		flexible_method = _data[-periods:]
-		for i in range(len(self.data[-1])):
+		n = n or len(self.data[-1])
+		for i in range(n):
 			flexible_method.append(flexible_method[i] * (self.__dvone + (percent / self.__dvhundred)))
 
 		# Remove the historical data needed for the first several forecast period calcs
@@ -193,13 +248,19 @@ class Forecast:
 
 		return self
 
-	def weighted_moving_average(self, periods: int, weights: list | tuple) -> "Forecast":
+	def weighted_moving_average(
+		self, periods: int, weights: list | tuple, n: int | None = None
+	) -> "Forecast":
 		"""
 		Similar to moving average, but applies the given `weights` to the `periods` included in
 		the average to generate the forecasted values.
 
-		The number of `weights` provided must match the number of `periods`, and must add to a
-		total of 1.
+		:param periods: the number of periods to include in the averaging calculation
+		:param weights: a sequence of values of type Decimal used to weight the periods in the
+		averaging calculation differently. The number of weights provided must match the number of
+		`periods`, and the sum of the weights must total 1
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		# Confirm weights are of Decimal type
 		if any([not isinstance(w, Decimal) for w in weights]):
@@ -208,8 +269,8 @@ class Forecast:
 		_data = self.__flat_data if periods > len(self.data[-1]) else self.data[-1]
 		if (periods - 1) > len(_data):
 			raise Exception("Cannot average more periods than existing in data.")
-		if sum(weights) != self.__dvone:
-			raise Exception("Total of weights must be exactly 1.")
+		if abs(sum(weights) - self.__dvone) > Decimal("1e-13"):
+			raise Exception(f"The sum of the weights must total 1. The given values sum to {sum(weights)}")
 		if len(weights) != periods:
 			raise Exception(
 				f"Weights must have as many elements as periods. Weights: {len(weights)} Periods: {periods}."
@@ -217,7 +278,8 @@ class Forecast:
 
 		weighted_moving_average_data = _data[-periods:]
 
-		for i in range(len(self.data[-1])):
+		n = n or len(self.data[-1])
+		for i in range(n):
 			weighted_moving_average_data.append(
 				sum(weights[j] * weighted_moving_average_data[i : i + periods][j] for j in range(len(weights)))
 			)
@@ -228,11 +290,15 @@ class Forecast:
 
 		return self
 
-	def linear_smoothing(self, periods: int) -> "Forecast":
+	def linear_smoothing(self, periods: int, n: int | None = None) -> "Forecast":
 		"""
-		Similar to the weighted moving average method, but instead of user-provided weights,
-		uses linearly-increasing weight values based on the number of `periods` to calculate
-		the average and generate the forecasted values.
+		Similar to the weighted moving average method, but instead of user-provided weights, uses
+		linearly-increasing weight values based on the number of `periods`. The calculated weights
+		are applied to the `periods` included in the average to generate the forecasted values.
+
+		:param periods: the number of periods to include in the averaging calculation
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		_data = self.__flat_data if periods > len(self.data[-1]) else self.data[-1]
 		if (periods - 1) > len(_data):
@@ -242,7 +308,8 @@ class Forecast:
 		weights = [Decimal(n) / W for n in range(1, periods + 1)]
 		linear_smoothing_data = _data[-periods:]
 
-		for i in range(len(self.data[-1])):
+		n = n or len(self.data[-1])
+		for i in range(n):
 			linear_smoothing_data.append(
 				sum(weights[j] * linear_smoothing_data[i : i + periods][j] for j in range(len(weights)))
 			)
@@ -253,11 +320,17 @@ class Forecast:
 
 		return self
 
-	def exponential_smoothing(self, periods: int, alpha: Decimal) -> "Forecast":
+	def exponential_smoothing(self, periods: int, alpha: Decimal, n: int | None = None) -> "Forecast":
 		"""
-		Applies calculated weights that are applied to the number of `periods` of data that are
-		exponentially decaying as they're applied to older data. The forecast is the last
-		calculated smoothed value for all forecasted periods.
+		Calculates a smoothed average over the given number of `periods` in the provided data and
+		uses the last calculated value for all forecasted periods. `alpha` is the smoothing
+		parameter - values closer to 1 put more weight on the actual data, values closer to 0 put
+		more weight on the previous period's smoothed value.
+
+		:param periods: the number of periods to include in the smoothing process
+		:param alpha: the smoothing parameter, must be a value between 0 and 1
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
 		"""
 		if not isinstance(alpha, Decimal):
 			raise TypeError("alpha must be of type Decimal.")
@@ -270,10 +343,11 @@ class Forecast:
 		smoothed = [_data[-periods]]
 		values = _data[-periods + 1 :]
 
+		n = n or len(self.data[-1])
 		for i, d in enumerate(values):
 			smoothed.append(alpha * d + (self.__dvone - alpha) * smoothed[i])
 
-		self.forecast = [smoothed[-1]] * len(self.data[-1])
+		self.forecast = [smoothed[-1]] * n
 
 		return self
 
@@ -281,6 +355,7 @@ class Forecast:
 		self,
 		alpha: Decimal,
 		beta: Decimal,
+		n: int | None = None,
 		seasonality: list[Decimal] | tuple[Decimal] | None = None,
 	) -> "Forecast":
 		"""
@@ -292,11 +367,21 @@ class Forecast:
 		`alpha` is the smoothing factor for the averaging of data, `beta` is the smoothing factor
 		for the trend component.
 
-		A list or tuple of `seasonality` factors may be optionally provided and must be the same
-		length as the most recent provided data. If it's not provided, then the method requires
-		two lists of provided historical data to make the calculation. Seasonality factors center
-		around 1 (in other words, the average of the provided seasonality factors must equal 1),
-		as they represent the contribution of a given period to the total.
+		A list or tuple of `seasonality` factors that represent the contribution of a given period
+		to the total may be optionally provided. (If not, the method calculates seasonality from
+		the sequence(s) of provided data.) Seasonality values must be factors that centers around
+		1 (in other words, the average of the seasonality values equals 1). If data is only
+		available as percents, they can be converted to factors by multiplying each percent by the
+		number of provided seasonality values. For example, a list of monthly seasonality values
+		for a year expressed as that month's percent of the annual total would be each multiplied
+		by 12 to get the equivalent factors.
+
+		:param alpha: the averaging smoothing parameter, must be a value between 0 and 1
+		:param beta: the trend smoothing parameter, must be a value between 0 and 1
+		:param n: the number of periods to forecast. If None, the forecast is same length as the
+		most recent previous period, which is stored as the last sequence in `data`
+		:param seasonality: sequence of seasonality factors for the number of periods the sequence
+		comprises
 		"""
 		if not isinstance(alpha, Decimal):
 			raise TypeError("alpha must be of type Decimal.")
@@ -308,26 +393,20 @@ class Forecast:
 			raise Exception("beta must be a value between 0 and 1.")
 		if seasonality and any([not isinstance(s, Decimal) for s in seasonality]):
 			raise TypeError("Seasonality values must be of type Decimal.")
-		if seasonality and len(seasonality) != len(self.data[-1]):
-			raise Exception(
-				"Provided seasonality values must be of same length as most recent provided data."
-			)
-		if seasonality and abs(Decimal(sum(seasonality)) - Decimal(len(seasonality))) > Decimal("1e-13"):
-			raise Exception(
-				"Provided seasonality values should sum to the total length, aka they must have an average value of 1."
-			)
 
 		# Calculate seasonality factors if not provided
 		if not seasonality:
 			seasonality = calculate_seasonality_factors(self.data)
+		avg_seasonality = cycle(seasonality)
+		fc_seasonality = cycle(seasonality)
 
-		# Initialize first value for averages and trends
-		averages = [self.data[-1][0] / seasonality[0]]
+		# Initialize first value for de-seasonalized averages and trends
+		averages = [self.data[-1][0] / next(avg_seasonality)]
 		trends = [self.__dvzero]
 
-		# Calculate the remaining averages and trends
+		# Calculate the remaining averages and trends in provided data
 		for i in range(1, len(self.data[-1])):
-			A_t = (alpha * (self.data[-1][i] / seasonality[i])) + (
+			A_t = (alpha * (self.data[-1][i] / next(avg_seasonality))) + (
 				(self.__dvone - alpha) * (averages[i - 1] + trends[i - 1])
 			)
 			T_t = beta * (A_t - averages[i - 1]) + ((self.__dvone - beta) * trends[i - 1])
@@ -335,8 +414,9 @@ class Forecast:
 			trends.append(T_t)
 
 		exponential_smoothing_trend_seasonality = []
-		for m in range(1, len(self.data[-1]) + 1):
-			F = (averages[-1] + (trends[-1] * Decimal(m))) * seasonality[m - 1]
+		n = n or len(self.data[-1])
+		for m in range(1, n + 1):
+			F = (averages[-1] + (trends[-1] * Decimal(m))) * next(fc_seasonality)
 			exponential_smoothing_trend_seasonality.append(F)
 
 		self.forecast = exponential_smoothing_trend_seasonality
@@ -523,12 +603,13 @@ def calculate_seasonality_factors(
 	data: typing.Sequence[typing.Sequence[Decimal]],
 ) -> list[Decimal]:
 	"""
-	Calculates seasonality from the provided `data` - a sequence of sequences of historical data
-	that are of type Decimal. The sequences in `data` must all be the same length (i.e. they all
-	have the same number of periods).
+	Calculates seasonality from the provided `data`, which should be a sequence of sequences of
+	historical data that are of type Decimal. The sequences in `data` should all be the same
+	length (i.e. they all have the same number of periods), but if not, the calculated seasonality
+	will be the same length as the shortest provided sequence in `data`.
 
-	Returns a list of seasonality factors centering around 1 of same length as each sequence in
-	`data`.
+	Returns a list of seasonality factors centering around 1 of same length as the shortest
+	sequence in `data`.
 	"""
 	if not data or any(not d for d in data):
 		raise Exception("Sequences of provided data may not be empty.")
@@ -536,10 +617,7 @@ def calculate_seasonality_factors(
 	if any([not isinstance(n, Decimal) for d in data for n in d]):
 		raise TypeError("Values in provided data must be of type Decimal.")
 
-	num_periods = len(data[-1])
-	if any([len(d) != num_periods for d in data]):
-		raise Exception("Historical sequences in data must all have the same number of periods.")
-
+	num_periods = min(len(d) for d in data)
 	total_units = Decimal(sum(sum(d) for d in data))
 	seasonality = [
 		(sum(hist_period[i] for hist_period in data) / total_units) * Decimal(num_periods)

--- a/forecast/forecast.py
+++ b/forecast/forecast.py
@@ -618,7 +618,7 @@ def calculate_seasonality_factors(
 		raise TypeError("Values in provided data must be of type Decimal.")
 
 	num_periods = min(len(d) for d in data)
-	total_units = Decimal(sum(sum(d) for d in data))
+	total_units = Decimal(sum(sum(d[:num_periods]) for d in data))
 	seasonality = [
 		(sum(hist_period[i] for hist_period in data) / total_units) * Decimal(num_periods)
 		for i in range(num_periods)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -77,8 +77,29 @@ def example_data_with_zeros():
 	)
 
 
-def test_percent_over_previous_period(example_data):
-	percent_over_previous_period_output = [
+@pytest.fixture
+def example_data_short():
+	return Forecast(
+		data=[
+			[
+				Decimal("90"),
+				Decimal("100"),
+				Decimal("110"),
+				Decimal("90"),
+			],
+			[
+				Decimal("100"),
+				Decimal("105"),
+				Decimal("120"),
+				Decimal("90"),
+			],
+		]
+	)
+
+
+def test_percent_over_previous_period(example_data, example_data_short):
+	percent = Decimal("10.00")
+	output = [
 		Decimal("137.5"),
 		Decimal("135.3"),
 		Decimal("126.5"),
@@ -92,13 +113,26 @@ def test_percent_over_previous_period(example_data):
 		Decimal("152.9"),
 		Decimal("146.3"),
 	]
-	fc = example_data.percent_over_previous_period(Decimal("10.0"))
+	fc = example_data.percent_over_previous_period(percent=percent)
 	for index, period in enumerate(fc.forecast):
-		assert period == percent_over_previous_period_output[index]
+		assert period == output[index]
+
+	n_output = [
+		Decimal("110"),
+		Decimal("115.5"),
+		Decimal("132"),
+		Decimal("99"),
+		Decimal("110"),
+		Decimal("115.5"),
+	]
+
+	fc = example_data_short.percent_over_previous_period(percent=percent, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert period == n_output[index]
 
 
-def test_previous_period_to_current_period(example_data):
-	percent_over_previous_period_output = [
+def test_previous_period_to_current_period(example_data, example_data_short):
+	output = [
 		Decimal("125"),
 		Decimal("123"),
 		Decimal("115"),
@@ -114,11 +148,24 @@ def test_previous_period_to_current_period(example_data):
 	]
 	fc = example_data.previous_period_to_current_period()
 	for index, period in enumerate(fc.forecast):
-		assert period == percent_over_previous_period_output[index]
+		assert period == output[index]
+
+	n_output = [
+		Decimal("100"),
+		Decimal("105"),
+		Decimal("120"),
+		Decimal("90"),
+		Decimal("100"),
+		Decimal("105"),
+	]
+
+	fc = example_data_short.previous_period_to_current_period(n=6)
+	for index, period in enumerate(fc.forecast):
+		assert period == n_output[index]
 
 
-def test_calculated_percent_over_previous_period(example_data):
-	calculated_percent_over_previous_period_output = [
+def test_calculated_percent_over_previous_period(example_data, example_data_short):
+	output = [
 		Decimal("126.6512549537648612945838838"),
 		Decimal("124.6248348745046235138705416"),
 		Decimal("116.5191545574636723910171730"),
@@ -134,11 +181,24 @@ def test_calculated_percent_over_previous_period(example_data):
 	]
 	fc = example_data.calculated_percent_over_previous_period()
 	for index, period in enumerate(fc.forecast):
-		assert period == calculated_percent_over_previous_period_output[index]
+		assert period == output[index]
+
+	n_output = [
+		Decimal("105"),
+		Decimal("110.25"),
+		Decimal("126"),
+		Decimal("94.5"),
+		Decimal("105"),
+		Decimal("110.25"),
+	]
+
+	fc = example_data_short.calculated_percent_over_previous_period(periods=2, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert period == n_output[index]
 
 
 def test_calculated_percent_over_previous_period_with_zeros(example_data_with_zeros):
-	calculated_percent_over_previous_period_with_zeros_output = [
+	output = [
 		Decimal("104.1941875825627476882430647"),
 		Decimal("102.5270805812417437252311757"),
 		Decimal("95.85865257595772787318361955"),
@@ -154,11 +214,11 @@ def test_calculated_percent_over_previous_period_with_zeros(example_data_with_ze
 	]
 	fc = example_data_with_zeros.calculated_percent_over_previous_period()
 	for index, period in enumerate(fc.forecast):
-		assert period == calculated_percent_over_previous_period_with_zeros_output[index]
+		assert period == output[index]
 
 
-def test_moving_average(example_data):
-	calculated_percent_over_previous_period_output = [
+def test_moving_average(example_data, example_data_short):
+	output = [
 		Decimal("127.8333333333333285963817615993320941925048828125"),
 		Decimal("128.0694444444444440496984802"),
 		Decimal("128.4918981481481477205066868"),
@@ -174,11 +234,24 @@ def test_moving_average(example_data):
 	]
 	fc = example_data.moving_average(12)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - calculated_percent_over_previous_period_output[index]) < Decimal("1e-14")
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	n_output = [
+		Decimal("105"),
+		Decimal("97.5"),
+		Decimal("101.25"),
+		Decimal("99.375"),
+		Decimal("100.3125"),
+		Decimal("99.84375"),
+	]
+
+	fc = example_data_short.moving_average(periods=2, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert period == n_output[index]
 
 
-def test_linear_approximation(example_data):
-	linear_approximation_output = [
+def test_linear_approximation(example_data, example_data_short):
+	output = [
 		Decimal("138"),
 		Decimal("143"),
 		Decimal("148"),
@@ -194,11 +267,24 @@ def test_linear_approximation(example_data):
 	]
 	fc = example_data.linear_approximation(3)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - linear_approximation_output[index]) < Decimal("1e-15")
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	n_output = [
+		Decimal("82.5"),
+		Decimal("75.0"),
+		Decimal("67.5"),
+		Decimal("60.0"),
+		Decimal("52.5"),
+		Decimal("45.0"),
+	]
+
+	fc = example_data_short.linear_approximation(periods=2, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert period == n_output[index]
 
 
-def test_least_squares_regression(example_data):
-	least_squares_regression_output = [
+def test_least_squares_regression(example_data, example_data_short):
+	output = [
 		Decimal("132.8787878787878753428230993449687957763671875"),
 		Decimal("133.6550116550116626967792399227619171142578125"),
 		Decimal("134.431235431235421629025950096547603607177734375"),
@@ -214,29 +300,42 @@ def test_least_squares_regression(example_data):
 	]
 	fc = example_data.least_squares_regression(12)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - least_squares_regression_output[index]) < Decimal("1e-13")
+		assert abs(period - output[index]) < Decimal("1e-13")
 
-
-def test_second_degree_approximation(example_data):
-	second_degree_approximation_output = [
-		Decimal("132.181818181818385937731363810598850250244140625"),
-		Decimal("132.63636363636391024556360207498073577880859375"),
-		Decimal("133.044955044955344192203483544290065765380859375"),
-		Decimal("133.407592407592773042779299430549144744873046875"),
-		Decimal("133.72427572427613995387218892574310302734375"),
-		Decimal("133.995004995005473347191582433879375457763671875"),
-		Decimal("134.219780219780801644446910358965396881103515625"),
-		Decimal("134.398601398602039580509881488978862762451171875"),
-		Decimal("134.531468531469243998799356631934642791748046875"),
-		Decimal("134.618381618382414899315335787832736968994140625"),
-		Decimal("134.65934065934152386034838855266571044921875"),
-		Decimal("134.654345654346656147026806138455867767333984375"),
+	n_output = [
+		Decimal("90.0"),
+		Decimal("82.5"),
+		Decimal("75.0"),
+		Decimal("67.5"),
+		Decimal("60.0"),
+		Decimal("52.5"),
 	]
-	fc = example_data.second_degree_approximation(12)
-	for index, period in enumerate(fc.forecast):
-		assert abs(period - second_degree_approximation_output[index]) < Decimal("1e-11")
 
-	second_degree_approximation_output_2 = [
+	fc = example_data_short.least_squares_regression(periods=3, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert period == n_output[index]
+
+
+def test_second_degree_approximation(example_data, example_data_short):
+	output = [
+		Decimal("132.1818181818181818181818183"),
+		Decimal("132.6363636363636363636363638"),
+		Decimal("133.0449550449550449550449552"),
+		Decimal("133.4075924075924075924075927"),
+		Decimal("133.7242757242757242757242760"),
+		Decimal("133.9950049950049950049950054"),
+		Decimal("134.2197802197802197802197806"),
+		Decimal("134.3986013986013986013986020"),
+		Decimal("134.5314685314685314685314692"),
+		Decimal("134.6183816183816183816183823"),
+		Decimal("134.6593406593406593406593415"),
+		Decimal("134.6543456543456543456543465"),
+	]
+	fc = example_data.second_degree_approximation(periods=12)
+	for index, period in enumerate(fc.forecast):
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	output_2 = [
 		Decimal("294.0000000000000000000000047"),
 		Decimal("172.0000000000000000000000116"),
 		Decimal("4.0000000000000000000000216"),
@@ -248,13 +347,27 @@ def test_second_degree_approximation(example_data):
 			Decimal("370"),
 		]
 	]
-	fc = Forecast(data=input_data).second_degree_approximation(3)
+	fc = Forecast(data=input_data).second_degree_approximation(periods=3)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - second_degree_approximation_output_2[index]) < Decimal("1e-11")
+		assert abs(period - output_2[index]) < Decimal("1e-13")
+
+	n_output = [
+		Decimal("97.00000000000000000000000017"),
+		Decimal("92.57142857142857142857142901"),
+		Decimal("87.07142857142857142857142923"),
+		Decimal("80.50000000000000000000000103"),
+		Decimal("72.85714285714285714285714422"),
+		Decimal("64.14285714285714285714285899"),
+	]
+
+	fc = example_data_short.second_degree_approximation(periods=6, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert abs(period - n_output[index]) < Decimal("1e-13")
 
 
-def test_flexible_method(example_data):
-	flexible_method_output = [
+def test_flexible_method(example_data, example_data_short):
+	percent = Decimal("10.00")
+	output = [
 		Decimal("137.5000000000000111022302463"),
 		Decimal("135.3000000000000109245945623"),
 		Decimal("126.5000000000000102140518266"),
@@ -268,12 +381,25 @@ def test_flexible_method(example_data):
 		Decimal("152.9000000000000123456800338"),
 		Decimal("146.3000000000000118127729820"),
 	]
-	fc = example_data.flexible_method(Decimal("10.00"), 12)
+	fc = example_data.flexible_method(percent=percent, periods=12)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - flexible_method_output[index]) < Decimal("1e-13")
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	n_output = [
+		Decimal("99.0"),
+		Decimal("108.90"),
+		Decimal("119.790"),
+		Decimal("131.7690"),
+		Decimal("144.94590"),
+		Decimal("159.440490"),
+	]
+
+	fc = example_data_short.flexible_method(percent=percent, periods=1, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert abs(period - n_output[index]) < Decimal("1e-13")
 
 
-def test_weighted_moving_average(example_data):
+def test_weighted_moving_average(example_data, example_data_short):
 	weights = [
 		Decimal("0.03"),
 		Decimal("0.03"),
@@ -288,7 +414,7 @@ def test_weighted_moving_average(example_data):
 		Decimal("0.15"),
 		Decimal("0.15"),
 	]
-	weighted_moving_average_output = [
+	output = [
 		Decimal("129.43999999999999772626324556767940521240234375"),
 		Decimal("129.385999999999995679900166578590869903564453125"),
 		Decimal("129.16390000000001236912794411182403564453125"),
@@ -302,13 +428,30 @@ def test_weighted_moving_average(example_data):
 		Decimal("130.141461720209207442167098633944988250732421875"),
 		Decimal("129.9160559217140189502970315515995025634765625"),
 	]
-	fc = example_data.weighted_moving_average(12, weights)
+	fc = example_data.weighted_moving_average(periods=12, weights=weights)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - weighted_moving_average_output[index]) < Decimal("1e-13")
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	n_weights = [
+		Decimal("0.25"),
+		Decimal("0.75"),
+	]
+	n_output = [
+		Decimal("97.50"),
+		Decimal("95.6250"),
+		Decimal("96.093750"),
+		Decimal("95.97656250"),
+		Decimal("96.0058593750"),
+		Decimal("95.998535156250"),
+	]
+
+	fc = example_data_short.weighted_moving_average(periods=2, weights=n_weights, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert abs(period - n_output[index]) < Decimal("1e-13")
 
 
-def test_linear_smoothing(example_data):
-	linear_smoothing_output = [
+def test_linear_smoothing(example_data, example_data_short):
+	output = [
 		Decimal("129.256410256410248393876827321946620941162109375"),
 		Decimal("129.47534516765284706707461737096309661865234375"),
 		Decimal("129.673393010671105685105430893599987030029296875"),
@@ -322,13 +465,27 @@ def test_linear_smoothing(example_data):
 		Decimal("130.030180450337383035730454139411449432373046875"),
 		Decimal("129.9122965381596941369934938848018646240234375"),
 	]
-	fc = example_data.linear_smoothing(12)
+	fc = example_data.linear_smoothing(periods=12)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - linear_smoothing_output[index]) < Decimal("1e-13")
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	n_output = [
+		Decimal("103.0"),
+		Decimal("102.70"),
+		Decimal("101.980"),
+		Decimal("101.2020"),
+		Decimal("101.91480"),
+		Decimal("101.792520"),
+	]
+
+	fc = example_data_short.linear_smoothing(periods=4, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert abs(period - n_output[index]) < Decimal("1e-13")
 
 
-def test_exponential_smoothing(example_data):
-	exponential_smoothing_output = [
+def test_exponential_smoothing(example_data, example_data_short):
+	alpha = Decimal("0.3")
+	output = [
 		Decimal("130.520404130059972658273181878030300140380859375"),
 		Decimal("130.520404130059972658273181878030300140380859375"),
 		Decimal("130.520404130059972658273181878030300140380859375"),
@@ -342,13 +499,26 @@ def test_exponential_smoothing(example_data):
 		Decimal("130.520404130059972658273181878030300140380859375"),
 		Decimal("130.520404130059972658273181878030300140380859375"),
 	]
-	fc = example_data.exponential_smoothing(12, Decimal("0.3"))
+	fc = example_data.exponential_smoothing(periods=12, alpha=alpha)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - exponential_smoothing_output[index]) < Decimal("1e-13")
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	n_output = [
+		Decimal("111.0"),
+		Decimal("111.0"),
+		Decimal("111.0"),
+		Decimal("111.0"),
+		Decimal("111.0"),
+		Decimal("111.0"),
+	]
+
+	fc = example_data_short.exponential_smoothing(periods=2, alpha=alpha, n=6)
+	for index, period in enumerate(fc.forecast):
+		assert abs(period - n_output[index]) < Decimal("1e-13")
 
 
-def test_exponential_smoothing_with_trend_and_seasonality(example_data):
-	exponential_smoothing__with_trend_and_seasonality_output = [
+def test_exponential_smoothing_with_trend_and_seasonality(example_data, example_data_short):
+	output = [
 		Decimal("128.8400382301657645281364115"),
 		Decimal("122.6708414308079670929446625"),
 		Decimal("117.9918052604130600843835623"),
@@ -362,11 +532,32 @@ def test_exponential_smoothing_with_trend_and_seasonality(example_data):
 		Decimal("136.2349889762650722004090835"),
 		Decimal("143.0789227005269950440901538"),
 	]
-	fc = example_data.exponential_smoothing_with_trend_and_seasonality(Decimal(0.3), Decimal(0.4))
+	fc = example_data.exponential_smoothing_with_trend_and_seasonality(
+		alpha=Decimal("0.3"), beta=Decimal("0.4")
+	)
 	for index, period in enumerate(fc.forecast):
-		assert abs(period - exponential_smoothing__with_trend_and_seasonality_output[index]) < Decimal(
-			"1e-13"
-		)
+		assert abs(period - output[index]) < Decimal("1e-13")
+
+	seasonality = [
+		Decimal("0.95"),
+		Decimal("1.00"),
+		Decimal("1.15"),
+		Decimal("0.90"),
+	]
+	n_output = [
+		Decimal("95"),
+		Decimal("100"),
+		Decimal("115"),
+		Decimal("90"),
+		Decimal("95"),
+		Decimal("100"),
+	]
+
+	fc = example_data_short.exponential_smoothing_with_trend_and_seasonality(
+		alpha=Decimal("1"), beta=Decimal("0"), seasonality=seasonality, n=6
+	)
+	for index, period in enumerate(fc.forecast):
+		assert abs(period - n_output[index]) < Decimal("1e-13")
 
 
 def test_seasonality(example_data):
@@ -522,30 +713,12 @@ def test_exponential_smoothing_with_trend_and_seasonality_errors(example_data):
 		s = [0.995, 0.982, 1.005, 1.028]
 		fc = example_data.exponential_smoothing_with_trend_and_seasonality(alpha, beta, seasonality=s)
 
-	# Test provided seasonality data different length than recent provided data
-	with pytest.raises(Exception):
-		s = [Decimal(1), Decimal(0.995), Decimal(1.005)]
-		fc = example_data.exponential_smoothing_with_trend_and_seasonality(alpha, beta, seasonality=s)
-
-	# Test provided seasonality factors aren't centered around (average) 1
-	with pytest.raises(Exception):
-		s = [Decimal(1), Decimal(2), Decimal(1)]
-		fc = example_data.exponential_smoothing_with_trend_and_seasonality(alpha, beta, seasonality=s)
-
 
 def test_seasonality_errors():
 	# Test no data provided
 	with pytest.raises(Exception):
-		s = calculate_seasonality_factors([[], [Decimal(1)]])
+		s = calculate_seasonality_factors([[], [Decimal("1")]])
 
 	# Test non-Decimal data
 	with pytest.raises(TypeError):
-		s = calculate_seasonality_factors([[1, Decimal(2)]])
-
-	# Test data of unequal lengths (different number of periods)
-	with pytest.raises(Exception):
-		d = [
-			[Decimal(1), Decimal(2), Decimal(3)],
-			[Decimal(0), Decimal(2)],
-		]
-		s = calculate_seasonality_factors(d)
+		s = calculate_seasonality_factors([[0.5, Decimal("0.5")]])

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -592,6 +592,11 @@ def test_seasonality(example_data):
 
 
 # Error testing
+def test_no_data_provided_error():
+	with pytest.raises(Exception):
+		fc = Forecast().previous_period_to_current_period()
+
+
 def test_non_decimal_data_error():
 	with pytest.raises(TypeError):
 		fc = Forecast(data=[[Decimal(1), Decimal(3), 5, Decimal(0)]])

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -581,6 +581,15 @@ def test_seasonality(example_data):
 	for index, s in enumerate(seasonality):
 		assert abs(s - seasonality_output[index]) < Decimal("1e-13")
 
+	# Test if data has sequences of unequal length, seasonality is same length as shorter of two
+	data = [
+		[Decimal("95"), Decimal("105"), Decimal("90")],
+		[Decimal("90"), Decimal("110")],
+	]
+	seasonality = calculate_seasonality_factors(data)
+	assert len(seasonality) == 2
+	assert abs(sum(seasonality) - 2) < Decimal("1e-13")
+
 
 # Error testing
 def test_non_decimal_data_error():


### PR DESCRIPTION
Closes #25 

Adds a new optional parameter to all Forecast methods so the user can specify how many periods to forecast. If it's not provided, maintains the previous behavior that the length of the forecast matches the number of periods in the most recent provided `data` (`self.data[-1]`).

- [x] update all methods for new parameter `n`
- [x] add tests for non-data-length forecast
- [x] docs are updated in PR #24 since that has a lot of explanation we need here already in it