### PR TITLE
ci: update version_variables name to capture version in __init__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ commands =
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]
-version_variable = [
+version_variables = [
     "forecast/__init__.py:__version__"
 ]
 


### PR DESCRIPTION
Quick PR to fix a misspelled keyword in pyproject.toml so Python Semantic Release updates the version variable in `__init__.py`.