### PR TITLE
feat: add fiscal weeks periodicity

### DIFF
--- a/date_binning.ipynb
+++ b/date_binning.ipynb
@@ -7,9 +7,11 @@
    "source": [
     "# Date Binning with the `Period` Class\n",
     "\n",
-    "The following code demonstrates various ways to use and apply the functionality in the `Period` class. In general, the class expects a date range defined with a `start_date` and `end_date`, and a `periodicity` (see options below). From there, it can generate date bins from `start_date` to `end_date` (inclusive by default) for the given `periodicity`. Date bins are in the form of a list of tuples, where each tuple contains that bin's start date and end date. The class can also convert given date bins from one periodicity to another, it can redistribute data from one periodicity to another given the data and original date bins, and can output pre-defined or custom labels.\n",
+    "The following code demonstrates various ways to use and apply the functionality in the `Period` class. In general, the class expects a date range defined with a `start_date` and `end_date`, and a `periodicity` (see options below). From there, it can generate date bins from `start_date` to `end_date` (inclusive by default) for the given `periodicity`. Date bins are in the form of a list of tuples, where each tuple contains that bin's start date and end date.\n",
     "\n",
-    "The class supports the following options for `periodicity`. The ISO options follow the ISO-8601 Standard. If a `periodicity` isn't provided, the default is \"ISO Week\".\n",
+    "The class can also convert given date bins from one periodicity to another, it can redistribute data from one periodicity to another given the data and original date bins, and can output pre-defined or custom labels.\n",
+    "\n",
+    "The class supports the following options for `periodicity`. The ISO options follow the ISO-8601 Standard and enforce a Monday week start - if a given `start_date` is not a Monday, there are side effects detailed in the \"Partial ('Stub') Periods\" section. The \"Fiscal Weeks\" `periodicity` may be a better option when Monday is not the week start. If a `periodicity` isn't provided, the default is \"ISO Week\".\n",
     "\n",
     "- \"ISO Week\" (default): weekly bins starting on a Monday\n",
     "- \"ISO Biweekly\": bins of 2 ISO week periods, grouping weeks 01 and 02, then 03 with 04, etc.\n",
@@ -19,9 +21,10 @@
     "- \"ISO Quarter (13 Weeks)\": quarterly bins of 13 ISO week periods. Quarter 1 is weeks 01-13, quarter 2 is weeks 14-26, etc.\n",
     "- \"ISO Semiannual (26 Weeks)\": semiannual bins of 26 ISO week periods. The first period is weeks 01-26 and second is weeks 27 to either 52 or 53, depending on the year\n",
     "- \"ISO Annual\": bins of full ISO years. If `start_date` is not the first day of the ISO year, the first bin will be a partial year\n",
-    "- \"Custom Days\": bins starting on `start_date` with a number of days between them as given by `custom_days` parameter in `get_date_bins`\n",
+    "- \"Custom Days\": bins starting on `start_date` with a number of days between them as given by the `custom_period` parameter in `get_date_bins` (this may be a single integer or a sequence that's cycled over)\n",
     "- \"Weekly\": weekly bins starting on `start_date`'s weekday\n",
     "- \"Biweekly\": bins of 2-week periods, starting on `start_date`'s weekday\n",
+    "- \"Fiscal Weeks\": bins starting on `start_date` with a number of weeks between them as given by the `custom_period` parameter in `get_date_bins` (this may be a single integer, like 13 weeks, or a sequence such as [4, 5, 4]). This option is similar to the ISO patterns, but counts weeks starting with the given `start_date`, regardless of which day of the week it is\n",
     "- \"Calendar Month\": bins by calendar month\n",
     "- \"Monthly\": monthly bins starting on `start_date`\n",
     "- \"Calendar Quarter\": bins of 3-month periods based on a calendar year (Jan-Mar, Apr-Jun, etc.)\n",
@@ -32,11 +35,15 @@
     "\n",
     "## Partial (\"Stub\") Periods\n",
     "\n",
-    "The `Period` class respects the user-provided `start_date` and `end_date`, even if they don't respect the convention of the `periodicity`. For example, if the user wants bins by \"Calendar Year\", but the `start_date` they provide is not January 1st, then the first bin will be a stub year from `start_date` to December 31st.\n",
+    "The `Period` class respects the user-provided `start_date` and `end_date`. Certain `periodicity` options, such as the ISO ones, adhere to standards, and others, such as the \"Calendar\"-based ones, follow convention. When user inputs don't align with those standards or conventions, then `get_date_bins` may include a partial, or \"stub\" period at the beginning or end of the date bins.\n",
     "\n",
-    "For all ISO periodicity options, if `start_date` is not a Monday or week 01 of any other ISO period, the first bin will represent a stub period. For periodicity options of \"Calendar Month\" and \"Calendar Year\", if `start_date` is not the first of that year, the first bin will represent a partial month/year. For \"Weekly\", \"Biweekly\", \"Calendar Quarter\", and \"Annually\" options, there's no concept of a partial period - it starts binning with `start_date` and counts off bins from there.\n",
+    "For example, if the user wants bins by \"Calendar Year\", but the `start_date` they provide is not January 1st, then the first bin will be a stub year from `start_date` to December 31st.\n",
     "\n",
-    "Not all `periodicity` choices create stub periods. Any option with \"ISO\" or \"Calendar\" in the name will create stub periods, as they all have defined starting and ending points. The options for \"Custom Days\", \"Weekly\", \"Biweekly\", \"Annually\", and \"Entire Period\" don't create stub periods, as they start binning from the `start_date`, regardless of which day of the week/month/year it is."
+    "For all ISO periodicity options, if `start_date` is not a Monday or week 01 of any other ISO period, the first bin will represent a stub period.\n",
+    "\n",
+    "For periodicity options of \"Calendar Month\", \"Calendar Quarter\", and \"Calendar Year\", if `start_date` is not the 1st of the period, the first bin will represent a partial month/quarter/year. \"Calendar Quarters\" are defined as January 31st to March 31st, April 30th to June 30th, July 31st to September 30th, and October 31st to December 31st.\n",
+    "\n",
+    "Not all `periodicity` choices create stub periods. For the \"Custom Days\", \"Weekly\", \"Biweekly\", \"Fiscal Weeks\", \"Monthly\", \"Quarterly\", and \"Annually\" options, there's no concept of a partial period - `get_date_bins` starts binning with `start_date` and generates the bins from there."
    ]
   },
   {
@@ -62,88 +69,101 @@
     "\n",
     "### Get Date Bins for ISO Week Periodicity\n",
     "\n",
-    "The following example creates date bins by ISO week for the current year. Since ISO years may have 52 or 53 weeks, the `n_weeks_in_cy` variable is used to get the week number for the final week of the year (December 28th is always in the last week of the ISO year).\n",
+    "The following example creates date bins by ISO week for the current year.\n",
     "\n",
-    "The default `periodicity` for the `Period` class is \"ISO Week\", so it's not necessary to provide it."
+    "The default `periodicity` for the `Period` class is \"ISO Week\", so it's not necessary to provide it. Also, `get_date_bins` has a parameter `inclusive` that by default is `True` - this means the given `end_date` is included in the bins. If it's set to `False`, then the bins will end the day before the given `end_date`, as the example below shows."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
+   "id": "d3e97098",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = Period().get_date_bins(start_date, end_date, \"ISO Week\", inclusive=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "688c0f15",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 1), datetime.date(2024, 1, 7)),\n",
-       " (datetime.date(2024, 1, 8), datetime.date(2024, 1, 14)),\n",
-       " (datetime.date(2024, 1, 15), datetime.date(2024, 1, 21)),\n",
-       " (datetime.date(2024, 1, 22), datetime.date(2024, 1, 28)),\n",
-       " (datetime.date(2024, 1, 29), datetime.date(2024, 2, 4)),\n",
-       " (datetime.date(2024, 2, 5), datetime.date(2024, 2, 11)),\n",
-       " (datetime.date(2024, 2, 12), datetime.date(2024, 2, 18)),\n",
-       " (datetime.date(2024, 2, 19), datetime.date(2024, 2, 25)),\n",
-       " (datetime.date(2024, 2, 26), datetime.date(2024, 3, 3)),\n",
-       " (datetime.date(2024, 3, 4), datetime.date(2024, 3, 10)),\n",
-       " (datetime.date(2024, 3, 11), datetime.date(2024, 3, 17)),\n",
-       " (datetime.date(2024, 3, 18), datetime.date(2024, 3, 24)),\n",
-       " (datetime.date(2024, 3, 25), datetime.date(2024, 3, 31)),\n",
-       " (datetime.date(2024, 4, 1), datetime.date(2024, 4, 7)),\n",
-       " (datetime.date(2024, 4, 8), datetime.date(2024, 4, 14)),\n",
-       " (datetime.date(2024, 4, 15), datetime.date(2024, 4, 21)),\n",
-       " (datetime.date(2024, 4, 22), datetime.date(2024, 4, 28)),\n",
-       " (datetime.date(2024, 4, 29), datetime.date(2024, 5, 5)),\n",
-       " (datetime.date(2024, 5, 6), datetime.date(2024, 5, 12)),\n",
-       " (datetime.date(2024, 5, 13), datetime.date(2024, 5, 19)),\n",
-       " (datetime.date(2024, 5, 20), datetime.date(2024, 5, 26)),\n",
-       " (datetime.date(2024, 5, 27), datetime.date(2024, 6, 2)),\n",
-       " (datetime.date(2024, 6, 3), datetime.date(2024, 6, 9)),\n",
-       " (datetime.date(2024, 6, 10), datetime.date(2024, 6, 16)),\n",
-       " (datetime.date(2024, 6, 17), datetime.date(2024, 6, 23)),\n",
-       " (datetime.date(2024, 6, 24), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 7, 7)),\n",
-       " (datetime.date(2024, 7, 8), datetime.date(2024, 7, 14)),\n",
-       " (datetime.date(2024, 7, 15), datetime.date(2024, 7, 21)),\n",
-       " (datetime.date(2024, 7, 22), datetime.date(2024, 7, 28)),\n",
-       " (datetime.date(2024, 7, 29), datetime.date(2024, 8, 4)),\n",
-       " (datetime.date(2024, 8, 5), datetime.date(2024, 8, 11)),\n",
-       " (datetime.date(2024, 8, 12), datetime.date(2024, 8, 18)),\n",
-       " (datetime.date(2024, 8, 19), datetime.date(2024, 8, 25)),\n",
-       " (datetime.date(2024, 8, 26), datetime.date(2024, 9, 1)),\n",
-       " (datetime.date(2024, 9, 2), datetime.date(2024, 9, 8)),\n",
-       " (datetime.date(2024, 9, 9), datetime.date(2024, 9, 15)),\n",
-       " (datetime.date(2024, 9, 16), datetime.date(2024, 9, 22)),\n",
-       " (datetime.date(2024, 9, 23), datetime.date(2024, 9, 29)),\n",
-       " (datetime.date(2024, 9, 30), datetime.date(2024, 10, 6)),\n",
-       " (datetime.date(2024, 10, 7), datetime.date(2024, 10, 13)),\n",
-       " (datetime.date(2024, 10, 14), datetime.date(2024, 10, 20)),\n",
-       " (datetime.date(2024, 10, 21), datetime.date(2024, 10, 27)),\n",
-       " (datetime.date(2024, 10, 28), datetime.date(2024, 11, 3)),\n",
-       " (datetime.date(2024, 11, 4), datetime.date(2024, 11, 10)),\n",
-       " (datetime.date(2024, 11, 11), datetime.date(2024, 11, 17)),\n",
-       " (datetime.date(2024, 11, 18), datetime.date(2024, 11, 24)),\n",
-       " (datetime.date(2024, 11, 25), datetime.date(2024, 12, 1)),\n",
-       " (datetime.date(2024, 12, 2), datetime.date(2024, 12, 8)),\n",
-       " (datetime.date(2024, 12, 9), datetime.date(2024, 12, 15)),\n",
-       " (datetime.date(2024, 12, 16), datetime.date(2024, 12, 22)),\n",
-       " (datetime.date(2024, 12, 23), datetime.date(2024, 12, 29))]"
+       "[(datetime.date(2024, 12, 30), datetime.date(2025, 1, 5)),\n",
+       " (datetime.date(2025, 1, 6), datetime.date(2025, 1, 12)),\n",
+       " (datetime.date(2025, 1, 13), datetime.date(2025, 1, 19)),\n",
+       " (datetime.date(2025, 1, 20), datetime.date(2025, 1, 26)),\n",
+       " (datetime.date(2025, 1, 27), datetime.date(2025, 2, 2)),\n",
+       " (datetime.date(2025, 2, 3), datetime.date(2025, 2, 9)),\n",
+       " (datetime.date(2025, 2, 10), datetime.date(2025, 2, 16)),\n",
+       " (datetime.date(2025, 2, 17), datetime.date(2025, 2, 23)),\n",
+       " (datetime.date(2025, 2, 24), datetime.date(2025, 3, 2)),\n",
+       " (datetime.date(2025, 3, 3), datetime.date(2025, 3, 9)),\n",
+       " (datetime.date(2025, 3, 10), datetime.date(2025, 3, 16)),\n",
+       " (datetime.date(2025, 3, 17), datetime.date(2025, 3, 23)),\n",
+       " (datetime.date(2025, 3, 24), datetime.date(2025, 3, 30)),\n",
+       " (datetime.date(2025, 3, 31), datetime.date(2025, 4, 6)),\n",
+       " (datetime.date(2025, 4, 7), datetime.date(2025, 4, 13)),\n",
+       " (datetime.date(2025, 4, 14), datetime.date(2025, 4, 20)),\n",
+       " (datetime.date(2025, 4, 21), datetime.date(2025, 4, 27)),\n",
+       " (datetime.date(2025, 4, 28), datetime.date(2025, 5, 4)),\n",
+       " (datetime.date(2025, 5, 5), datetime.date(2025, 5, 11)),\n",
+       " (datetime.date(2025, 5, 12), datetime.date(2025, 5, 18)),\n",
+       " (datetime.date(2025, 5, 19), datetime.date(2025, 5, 25)),\n",
+       " (datetime.date(2025, 5, 26), datetime.date(2025, 6, 1)),\n",
+       " (datetime.date(2025, 6, 2), datetime.date(2025, 6, 8)),\n",
+       " (datetime.date(2025, 6, 9), datetime.date(2025, 6, 15)),\n",
+       " (datetime.date(2025, 6, 16), datetime.date(2025, 6, 22)),\n",
+       " (datetime.date(2025, 6, 23), datetime.date(2025, 6, 29)),\n",
+       " (datetime.date(2025, 6, 30), datetime.date(2025, 7, 6)),\n",
+       " (datetime.date(2025, 7, 7), datetime.date(2025, 7, 13)),\n",
+       " (datetime.date(2025, 7, 14), datetime.date(2025, 7, 20)),\n",
+       " (datetime.date(2025, 7, 21), datetime.date(2025, 7, 27)),\n",
+       " (datetime.date(2025, 7, 28), datetime.date(2025, 8, 3)),\n",
+       " (datetime.date(2025, 8, 4), datetime.date(2025, 8, 10)),\n",
+       " (datetime.date(2025, 8, 11), datetime.date(2025, 8, 17)),\n",
+       " (datetime.date(2025, 8, 18), datetime.date(2025, 8, 24)),\n",
+       " (datetime.date(2025, 8, 25), datetime.date(2025, 8, 31)),\n",
+       " (datetime.date(2025, 9, 1), datetime.date(2025, 9, 7)),\n",
+       " (datetime.date(2025, 9, 8), datetime.date(2025, 9, 14)),\n",
+       " (datetime.date(2025, 9, 15), datetime.date(2025, 9, 21)),\n",
+       " (datetime.date(2025, 9, 22), datetime.date(2025, 9, 28)),\n",
+       " (datetime.date(2025, 9, 29), datetime.date(2025, 10, 5)),\n",
+       " (datetime.date(2025, 10, 6), datetime.date(2025, 10, 12)),\n",
+       " (datetime.date(2025, 10, 13), datetime.date(2025, 10, 19)),\n",
+       " (datetime.date(2025, 10, 20), datetime.date(2025, 10, 26)),\n",
+       " (datetime.date(2025, 10, 27), datetime.date(2025, 11, 2)),\n",
+       " (datetime.date(2025, 11, 3), datetime.date(2025, 11, 9)),\n",
+       " (datetime.date(2025, 11, 10), datetime.date(2025, 11, 16)),\n",
+       " (datetime.date(2025, 11, 17), datetime.date(2025, 11, 23)),\n",
+       " (datetime.date(2025, 11, 24), datetime.date(2025, 11, 30)),\n",
+       " (datetime.date(2025, 12, 1), datetime.date(2025, 12, 7)),\n",
+       " (datetime.date(2025, 12, 8), datetime.date(2025, 12, 14)),\n",
+       " (datetime.date(2025, 12, 15), datetime.date(2025, 12, 21)),\n",
+       " (datetime.date(2025, 12, 22), datetime.date(2025, 12, 28))]"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "current_year = datetime.datetime.now().year\n",
-    "n_weeks_in_cy = datetime.date(current_year, 12, 28).isocalendar().week\n",
     "start_date = datetime.date.fromisocalendar(current_year, 1, 1)\n",
-    "end_date = datetime.date.fromisocalendar(current_year, n_weeks_in_cy, 7)\n",
+    "end_date = datetime.date.fromisocalendar(current_year + 1, 1, 1)\n",
     "\n",
     "# Create an instance of Period and generate the date bins\n",
-    "p = Period(start_date=start_date, end_date=end_date)\n",
-    "bins = p.get_date_bins()\n",
+    "p = Period(start_date=start_date, end_date=end_date, periodicity=\"ISO Week\")\n",
+    "bins = p.get_date_bins(inclusive=False)\n",
+    "\n",
+    "# Alternative way to call the class and method:\n",
+    "# bins = Period().get_date_bins(start_date, end_date, \"ISO Week\", inclusive=False)\n",
+    "\n",
     "bins"
    ]
   },
@@ -157,20 +177,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "id": "44f3f617",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 3), datetime.date(2024, 1, 7)),\n",
-       " (datetime.date(2024, 1, 8), datetime.date(2024, 1, 14)),\n",
-       " (datetime.date(2024, 1, 15), datetime.date(2024, 1, 21)),\n",
-       " (datetime.date(2024, 1, 22), datetime.date(2024, 1, 26))]"
+       "[(datetime.date(2025, 1, 1), datetime.date(2025, 1, 5)),\n",
+       " (datetime.date(2025, 1, 6), datetime.date(2025, 1, 12)),\n",
+       " (datetime.date(2025, 1, 13), datetime.date(2025, 1, 19)),\n",
+       " (datetime.date(2025, 1, 20), datetime.date(2025, 1, 24))]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -194,22 +214,22 @@
     "\n",
     "The `Period` class has the `get_period_labels` method to generate labels for given date bins. It has built-in formats for all periodicity options, or the user can provide their own format string to suit their needs. The method supports any Python [strftime formatters](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes), which uses the 1989 C standard.\n",
     "\n",
-    "If a custom format is provided, the user can also indicate which date for each bin - the bin's start date or the bin's end date - to use to create the labels. The built-in formats use the bin's start date for ISO-based periodicity options and the bin's end date for the others, with the exception of the \"Entire Period\" periodicity, which uses both dates."
+    "If the user provides a custom format, they can also indicate which date for each bin - the bin's start date or the bin's end date - to use to create the labels with the `use_bin_start_date_for_label` parameter. If the user doesn't provide this, the built-in formats use the bin's start date for ISO-based periodicity options and the bin's end date for the others, with the exception of the \"Entire Period\" periodicity, which uses both dates."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "id": "94eeaf95",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Week 1-24', 'Week 2-24', 'Week 3-24', 'Week 4-24']"
+       "['Week 1-25', 'Week 2-25', 'Week 3-25', 'Week 4-25']"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -221,17 +241,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "id": "4c2529c0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Jan-07', 'Jan-14', 'Jan-21', 'Jan-26']"
+       "['Jan-05', 'Jan-12', 'Jan-19', 'Jan-24']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,27 +278,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "id": "d1136250",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 1), datetime.date(2024, 3, 31)),\n",
-       " (datetime.date(2024, 4, 1), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 9, 29)),\n",
-       " (datetime.date(2024, 9, 30), datetime.date(2024, 12, 29))]"
+       "[(datetime.date(2024, 12, 30), datetime.date(2025, 3, 30)),\n",
+       " (datetime.date(2025, 3, 31), datetime.date(2025, 6, 29)),\n",
+       " (datetime.date(2025, 6, 30), datetime.date(2025, 9, 28)),\n",
+       " (datetime.date(2025, 9, 29), datetime.date(2025, 12, 28))]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "start_date = datetime.date.fromisocalendar(current_year, 1, 1)\n",
-    "end_date = datetime.date.fromisocalendar(current_year, n_weeks_in_cy, 7)\n",
+    "end_date = datetime.date.fromisocalendar(current_year + 1, 1, 1) - relativedelta(days=1)\n",
     "\n",
     "# Create an instance of Period and generate the date bins\n",
     "p = Period(start_date=start_date, end_date=end_date)\n",
@@ -291,17 +311,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "id": "15c1a179",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Q1-24', 'Q2-24', 'Q3-24', 'Q4-24']"
+       "['Q1-25', 'Q2-25', 'Q3-25', 'Q4-25']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,29 +344,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "id": "4a8a8486",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OrderedDict([((datetime.date(2024, 1, 1), datetime.date(2024, 3, 31)),\n",
+       "OrderedDict([((datetime.date(2024, 12, 30), datetime.date(2025, 3, 30)),\n",
        "              Decimal('1299.999999999999999999999995')),\n",
-       "             ((datetime.date(2024, 4, 1), datetime.date(2024, 6, 30)),\n",
+       "             ((datetime.date(2025, 3, 31), datetime.date(2025, 6, 29)),\n",
        "              Decimal('2600.000000000000000000000025')),\n",
-       "             ((datetime.date(2024, 7, 1), datetime.date(2024, 9, 29)),\n",
+       "             ((datetime.date(2025, 6, 30), datetime.date(2025, 9, 28)),\n",
        "              Decimal('3900.000000000000000000000010')),\n",
-       "             ((datetime.date(2024, 9, 30), datetime.date(2024, 12, 29)),\n",
+       "             ((datetime.date(2025, 9, 29), datetime.date(2025, 12, 28)),\n",
        "              Decimal('1299.999999999999999999999995'))])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "n_weeks_in_cy = datetime.date(current_year, 12, 28).isocalendar().week\n",
     "data = [100] * 13 + [200] * 13 + [300] * 13 + [100] * 13\n",
     "data = data + ([100] if n_weeks_in_cy == 53 else [])\n",
     "\n",
@@ -371,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "id": "7e9e321b",
    "metadata": {},
    "outputs": [
@@ -379,7 +400,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Start Date: 2023-12-25, End Date: 2025-01-05\n"
+      "Start Date: 2024-12-23, End Date: 2026-01-04\n"
      ]
     }
    ],
@@ -394,44 +415,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "id": "67766685",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2023, 12, 25), datetime.date(2023, 12, 31)),\n",
-       " (datetime.date(2024, 1, 1), datetime.date(2024, 1, 14)),\n",
-       " (datetime.date(2024, 1, 15), datetime.date(2024, 1, 28)),\n",
-       " (datetime.date(2024, 1, 29), datetime.date(2024, 2, 11)),\n",
-       " (datetime.date(2024, 2, 12), datetime.date(2024, 2, 25)),\n",
-       " (datetime.date(2024, 2, 26), datetime.date(2024, 3, 10)),\n",
-       " (datetime.date(2024, 3, 11), datetime.date(2024, 3, 24)),\n",
-       " (datetime.date(2024, 3, 25), datetime.date(2024, 4, 7)),\n",
-       " (datetime.date(2024, 4, 8), datetime.date(2024, 4, 21)),\n",
-       " (datetime.date(2024, 4, 22), datetime.date(2024, 5, 5)),\n",
-       " (datetime.date(2024, 5, 6), datetime.date(2024, 5, 19)),\n",
-       " (datetime.date(2024, 5, 20), datetime.date(2024, 6, 2)),\n",
-       " (datetime.date(2024, 6, 3), datetime.date(2024, 6, 16)),\n",
-       " (datetime.date(2024, 6, 17), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 7, 14)),\n",
-       " (datetime.date(2024, 7, 15), datetime.date(2024, 7, 28)),\n",
-       " (datetime.date(2024, 7, 29), datetime.date(2024, 8, 11)),\n",
-       " (datetime.date(2024, 8, 12), datetime.date(2024, 8, 25)),\n",
-       " (datetime.date(2024, 8, 26), datetime.date(2024, 9, 8)),\n",
-       " (datetime.date(2024, 9, 9), datetime.date(2024, 9, 22)),\n",
-       " (datetime.date(2024, 9, 23), datetime.date(2024, 10, 6)),\n",
-       " (datetime.date(2024, 10, 7), datetime.date(2024, 10, 20)),\n",
-       " (datetime.date(2024, 10, 21), datetime.date(2024, 11, 3)),\n",
-       " (datetime.date(2024, 11, 4), datetime.date(2024, 11, 17)),\n",
-       " (datetime.date(2024, 11, 18), datetime.date(2024, 12, 1)),\n",
-       " (datetime.date(2024, 12, 2), datetime.date(2024, 12, 15)),\n",
-       " (datetime.date(2024, 12, 16), datetime.date(2024, 12, 29)),\n",
-       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2024, 12, 23), datetime.date(2024, 12, 29)),\n",
+       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 12)),\n",
+       " (datetime.date(2025, 1, 13), datetime.date(2025, 1, 26)),\n",
+       " (datetime.date(2025, 1, 27), datetime.date(2025, 2, 9)),\n",
+       " (datetime.date(2025, 2, 10), datetime.date(2025, 2, 23)),\n",
+       " (datetime.date(2025, 2, 24), datetime.date(2025, 3, 9)),\n",
+       " (datetime.date(2025, 3, 10), datetime.date(2025, 3, 23)),\n",
+       " (datetime.date(2025, 3, 24), datetime.date(2025, 4, 6)),\n",
+       " (datetime.date(2025, 4, 7), datetime.date(2025, 4, 20)),\n",
+       " (datetime.date(2025, 4, 21), datetime.date(2025, 5, 4)),\n",
+       " (datetime.date(2025, 5, 5), datetime.date(2025, 5, 18)),\n",
+       " (datetime.date(2025, 5, 19), datetime.date(2025, 6, 1)),\n",
+       " (datetime.date(2025, 6, 2), datetime.date(2025, 6, 15)),\n",
+       " (datetime.date(2025, 6, 16), datetime.date(2025, 6, 29)),\n",
+       " (datetime.date(2025, 6, 30), datetime.date(2025, 7, 13)),\n",
+       " (datetime.date(2025, 7, 14), datetime.date(2025, 7, 27)),\n",
+       " (datetime.date(2025, 7, 28), datetime.date(2025, 8, 10)),\n",
+       " (datetime.date(2025, 8, 11), datetime.date(2025, 8, 24)),\n",
+       " (datetime.date(2025, 8, 25), datetime.date(2025, 9, 7)),\n",
+       " (datetime.date(2025, 9, 8), datetime.date(2025, 9, 21)),\n",
+       " (datetime.date(2025, 9, 22), datetime.date(2025, 10, 5)),\n",
+       " (datetime.date(2025, 10, 6), datetime.date(2025, 10, 19)),\n",
+       " (datetime.date(2025, 10, 20), datetime.date(2025, 11, 2)),\n",
+       " (datetime.date(2025, 11, 3), datetime.date(2025, 11, 16)),\n",
+       " (datetime.date(2025, 11, 17), datetime.date(2025, 11, 30)),\n",
+       " (datetime.date(2025, 12, 1), datetime.date(2025, 12, 14)),\n",
+       " (datetime.date(2025, 12, 15), datetime.date(2025, 12, 28)),\n",
+       " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -444,44 +465,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "id": "3c496396",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Weeks 52-52 23',\n",
-       " 'Weeks 1-2 24',\n",
-       " 'Weeks 3-4 24',\n",
-       " 'Weeks 5-6 24',\n",
-       " 'Weeks 7-8 24',\n",
-       " 'Weeks 9-10 24',\n",
-       " 'Weeks 11-12 24',\n",
-       " 'Weeks 13-14 24',\n",
-       " 'Weeks 15-16 24',\n",
-       " 'Weeks 17-18 24',\n",
-       " 'Weeks 19-20 24',\n",
-       " 'Weeks 21-22 24',\n",
-       " 'Weeks 23-24 24',\n",
-       " 'Weeks 25-26 24',\n",
-       " 'Weeks 27-28 24',\n",
-       " 'Weeks 29-30 24',\n",
-       " 'Weeks 31-32 24',\n",
-       " 'Weeks 33-34 24',\n",
-       " 'Weeks 35-36 24',\n",
-       " 'Weeks 37-38 24',\n",
-       " 'Weeks 39-40 24',\n",
-       " 'Weeks 41-42 24',\n",
-       " 'Weeks 43-44 24',\n",
-       " 'Weeks 45-46 24',\n",
-       " 'Weeks 47-48 24',\n",
-       " 'Weeks 49-50 24',\n",
-       " 'Weeks 51-52 24',\n",
-       " 'Weeks 1-1 25']"
+       "['Weeks 52-52 24',\n",
+       " 'Weeks 1-2 25',\n",
+       " 'Weeks 3-4 25',\n",
+       " 'Weeks 5-6 25',\n",
+       " 'Weeks 7-8 25',\n",
+       " 'Weeks 9-10 25',\n",
+       " 'Weeks 11-12 25',\n",
+       " 'Weeks 13-14 25',\n",
+       " 'Weeks 15-16 25',\n",
+       " 'Weeks 17-18 25',\n",
+       " 'Weeks 19-20 25',\n",
+       " 'Weeks 21-22 25',\n",
+       " 'Weeks 23-24 25',\n",
+       " 'Weeks 25-26 25',\n",
+       " 'Weeks 27-28 25',\n",
+       " 'Weeks 29-30 25',\n",
+       " 'Weeks 31-32 25',\n",
+       " 'Weeks 33-34 25',\n",
+       " 'Weeks 35-36 25',\n",
+       " 'Weeks 37-38 25',\n",
+       " 'Weeks 39-40 25',\n",
+       " 'Weeks 41-42 25',\n",
+       " 'Weeks 43-44 25',\n",
+       " 'Weeks 45-46 25',\n",
+       " 'Weeks 47-48 25',\n",
+       " 'Weeks 49-50 25',\n",
+       " 'Weeks 51-52 25',\n",
+       " 'Weeks 1-1 26']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,31 +524,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "id": "b99eb5d2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2023, 12, 25), datetime.date(2023, 12, 31)),\n",
-       " (datetime.date(2024, 1, 1), datetime.date(2024, 1, 28)),\n",
-       " (datetime.date(2024, 1, 29), datetime.date(2024, 2, 25)),\n",
-       " (datetime.date(2024, 2, 26), datetime.date(2024, 3, 24)),\n",
-       " (datetime.date(2024, 3, 25), datetime.date(2024, 4, 21)),\n",
-       " (datetime.date(2024, 4, 22), datetime.date(2024, 5, 19)),\n",
-       " (datetime.date(2024, 5, 20), datetime.date(2024, 6, 16)),\n",
-       " (datetime.date(2024, 6, 17), datetime.date(2024, 7, 14)),\n",
-       " (datetime.date(2024, 7, 15), datetime.date(2024, 8, 11)),\n",
-       " (datetime.date(2024, 8, 12), datetime.date(2024, 9, 8)),\n",
-       " (datetime.date(2024, 9, 9), datetime.date(2024, 10, 6)),\n",
-       " (datetime.date(2024, 10, 7), datetime.date(2024, 11, 3)),\n",
-       " (datetime.date(2024, 11, 4), datetime.date(2024, 12, 1)),\n",
-       " (datetime.date(2024, 12, 2), datetime.date(2024, 12, 29)),\n",
-       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2024, 12, 23), datetime.date(2024, 12, 29)),\n",
+       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 26)),\n",
+       " (datetime.date(2025, 1, 27), datetime.date(2025, 2, 23)),\n",
+       " (datetime.date(2025, 2, 24), datetime.date(2025, 3, 23)),\n",
+       " (datetime.date(2025, 3, 24), datetime.date(2025, 4, 20)),\n",
+       " (datetime.date(2025, 4, 21), datetime.date(2025, 5, 18)),\n",
+       " (datetime.date(2025, 5, 19), datetime.date(2025, 6, 15)),\n",
+       " (datetime.date(2025, 6, 16), datetime.date(2025, 7, 13)),\n",
+       " (datetime.date(2025, 7, 14), datetime.date(2025, 8, 10)),\n",
+       " (datetime.date(2025, 8, 11), datetime.date(2025, 9, 7)),\n",
+       " (datetime.date(2025, 9, 8), datetime.date(2025, 10, 5)),\n",
+       " (datetime.date(2025, 10, 6), datetime.date(2025, 11, 2)),\n",
+       " (datetime.date(2025, 11, 3), datetime.date(2025, 11, 30)),\n",
+       " (datetime.date(2025, 12, 1), datetime.date(2025, 12, 28)),\n",
+       " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -540,31 +561,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 19,
    "id": "52d5b805",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['M13 (4w)-23',\n",
-       " 'Jan (4w)-24',\n",
-       " 'Feb (4w)-24',\n",
-       " 'Mar (4w)-24',\n",
-       " 'Apr (4w)-24',\n",
-       " 'May (4w)-24',\n",
-       " 'Jun (4w)-24',\n",
-       " 'Jul (4w)-24',\n",
-       " 'Aug (4w)-24',\n",
-       " 'Sep (4w)-24',\n",
-       " 'Oct (4w)-24',\n",
-       " 'Nov (4w)-24',\n",
-       " 'Dec (4w)-24',\n",
-       " 'M13 (4w)-24',\n",
-       " 'Jan (4w)-25']"
+       "['M13 (4w)-24',\n",
+       " 'Jan (4w)-25',\n",
+       " 'Feb (4w)-25',\n",
+       " 'Mar (4w)-25',\n",
+       " 'Apr (4w)-25',\n",
+       " 'May (4w)-25',\n",
+       " 'Jun (4w)-25',\n",
+       " 'Jul (4w)-25',\n",
+       " 'Aug (4w)-25',\n",
+       " 'Sep (4w)-25',\n",
+       " 'Oct (4w)-25',\n",
+       " 'Nov (4w)-25',\n",
+       " 'Dec (4w)-25',\n",
+       " 'M13 (4w)-25',\n",
+       " 'Jan (4w)-26']"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -586,30 +607,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 20,
    "id": "34a02c5f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2023, 12, 25), datetime.date(2023, 12, 31)),\n",
-       " (datetime.date(2024, 1, 1), datetime.date(2024, 1, 28)),\n",
-       " (datetime.date(2024, 1, 29), datetime.date(2024, 3, 3)),\n",
-       " (datetime.date(2024, 3, 4), datetime.date(2024, 3, 31)),\n",
-       " (datetime.date(2024, 4, 1), datetime.date(2024, 4, 28)),\n",
-       " (datetime.date(2024, 4, 29), datetime.date(2024, 6, 2)),\n",
-       " (datetime.date(2024, 6, 3), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 7, 28)),\n",
-       " (datetime.date(2024, 7, 29), datetime.date(2024, 9, 1)),\n",
-       " (datetime.date(2024, 9, 2), datetime.date(2024, 9, 29)),\n",
-       " (datetime.date(2024, 9, 30), datetime.date(2024, 10, 27)),\n",
-       " (datetime.date(2024, 10, 28), datetime.date(2024, 12, 1)),\n",
-       " (datetime.date(2024, 12, 2), datetime.date(2024, 12, 29)),\n",
-       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2024, 12, 23), datetime.date(2024, 12, 29)),\n",
+       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 26)),\n",
+       " (datetime.date(2025, 1, 27), datetime.date(2025, 3, 2)),\n",
+       " (datetime.date(2025, 3, 3), datetime.date(2025, 3, 30)),\n",
+       " (datetime.date(2025, 3, 31), datetime.date(2025, 4, 27)),\n",
+       " (datetime.date(2025, 4, 28), datetime.date(2025, 6, 1)),\n",
+       " (datetime.date(2025, 6, 2), datetime.date(2025, 6, 29)),\n",
+       " (datetime.date(2025, 6, 30), datetime.date(2025, 7, 27)),\n",
+       " (datetime.date(2025, 7, 28), datetime.date(2025, 8, 31)),\n",
+       " (datetime.date(2025, 9, 1), datetime.date(2025, 9, 28)),\n",
+       " (datetime.date(2025, 9, 29), datetime.date(2025, 10, 26)),\n",
+       " (datetime.date(2025, 10, 27), datetime.date(2025, 11, 30)),\n",
+       " (datetime.date(2025, 12, 1), datetime.date(2025, 12, 28)),\n",
+       " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -622,30 +643,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 21,
    "id": "32524f3c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Dec (4w)-23',\n",
-       " 'Jan (4w)-24',\n",
-       " 'Feb (5w)-24',\n",
-       " 'Mar (4w)-24',\n",
-       " 'Apr (4w)-24',\n",
-       " 'May (5w)-24',\n",
-       " 'Jun (4w)-24',\n",
-       " 'Jul (4w)-24',\n",
-       " 'Aug (5w)-24',\n",
-       " 'Sep (4w)-24',\n",
-       " 'Oct (4w)-24',\n",
-       " 'Nov (5w)-24',\n",
-       " 'Dec (4w)-24',\n",
-       " 'Jan (4w)-25']"
+       "['Dec (4w)-24',\n",
+       " 'Jan (4w)-25',\n",
+       " 'Feb (5w)-25',\n",
+       " 'Mar (4w)-25',\n",
+       " 'Apr (4w)-25',\n",
+       " 'May (5w)-25',\n",
+       " 'Jun (4w)-25',\n",
+       " 'Jul (4w)-25',\n",
+       " 'Aug (5w)-25',\n",
+       " 'Sep (4w)-25',\n",
+       " 'Oct (4w)-25',\n",
+       " 'Nov (5w)-25',\n",
+       " 'Dec (4w)-25',\n",
+       " 'Jan (4w)-26']"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -667,30 +688,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 22,
    "id": "ea0e27dd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2023, 12, 25), datetime.date(2023, 12, 31)),\n",
-       " (datetime.date(2024, 1, 1), datetime.date(2024, 1, 28)),\n",
-       " (datetime.date(2024, 1, 29), datetime.date(2024, 2, 25)),\n",
-       " (datetime.date(2024, 2, 26), datetime.date(2024, 3, 31)),\n",
-       " (datetime.date(2024, 4, 1), datetime.date(2024, 4, 28)),\n",
-       " (datetime.date(2024, 4, 29), datetime.date(2024, 5, 26)),\n",
-       " (datetime.date(2024, 5, 27), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 7, 28)),\n",
-       " (datetime.date(2024, 7, 29), datetime.date(2024, 8, 25)),\n",
-       " (datetime.date(2024, 8, 26), datetime.date(2024, 9, 29)),\n",
-       " (datetime.date(2024, 9, 30), datetime.date(2024, 10, 27)),\n",
-       " (datetime.date(2024, 10, 28), datetime.date(2024, 11, 24)),\n",
-       " (datetime.date(2024, 11, 25), datetime.date(2024, 12, 29)),\n",
-       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2024, 12, 23), datetime.date(2024, 12, 29)),\n",
+       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 26)),\n",
+       " (datetime.date(2025, 1, 27), datetime.date(2025, 2, 23)),\n",
+       " (datetime.date(2025, 2, 24), datetime.date(2025, 3, 30)),\n",
+       " (datetime.date(2025, 3, 31), datetime.date(2025, 4, 27)),\n",
+       " (datetime.date(2025, 4, 28), datetime.date(2025, 5, 25)),\n",
+       " (datetime.date(2025, 5, 26), datetime.date(2025, 6, 29)),\n",
+       " (datetime.date(2025, 6, 30), datetime.date(2025, 7, 27)),\n",
+       " (datetime.date(2025, 7, 28), datetime.date(2025, 8, 24)),\n",
+       " (datetime.date(2025, 8, 25), datetime.date(2025, 9, 28)),\n",
+       " (datetime.date(2025, 9, 29), datetime.date(2025, 10, 26)),\n",
+       " (datetime.date(2025, 10, 27), datetime.date(2025, 11, 23)),\n",
+       " (datetime.date(2025, 11, 24), datetime.date(2025, 12, 28)),\n",
+       " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -703,30 +724,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 23,
    "id": "6e4c9559",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Dec (5w)-23',\n",
-       " 'Jan (4w)-24',\n",
-       " 'Feb (4w)-24',\n",
-       " 'Mar (5w)-24',\n",
-       " 'Apr (4w)-24',\n",
-       " 'May (4w)-24',\n",
-       " 'Jun (5w)-24',\n",
-       " 'Jul (4w)-24',\n",
-       " 'Aug (4w)-24',\n",
-       " 'Sep (5w)-24',\n",
-       " 'Oct (4w)-24',\n",
-       " 'Nov (4w)-24',\n",
-       " 'Dec (5w)-24',\n",
-       " 'Jan (4w)-25']"
+       "['Dec (5w)-24',\n",
+       " 'Jan (4w)-25',\n",
+       " 'Feb (4w)-25',\n",
+       " 'Mar (5w)-25',\n",
+       " 'Apr (4w)-25',\n",
+       " 'May (4w)-25',\n",
+       " 'Jun (5w)-25',\n",
+       " 'Jul (4w)-25',\n",
+       " 'Aug (4w)-25',\n",
+       " 'Sep (5w)-25',\n",
+       " 'Oct (4w)-25',\n",
+       " 'Nov (4w)-25',\n",
+       " 'Dec (5w)-25',\n",
+       " 'Jan (4w)-26']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -748,22 +769,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 24,
    "id": "1159bde4",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2023, 12, 25), datetime.date(2023, 12, 31)),\n",
-       " (datetime.date(2024, 1, 1), datetime.date(2024, 3, 31)),\n",
-       " (datetime.date(2024, 4, 1), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 9, 29)),\n",
-       " (datetime.date(2024, 9, 30), datetime.date(2024, 12, 29)),\n",
-       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2024, 12, 23), datetime.date(2024, 12, 29)),\n",
+       " (datetime.date(2024, 12, 30), datetime.date(2025, 3, 30)),\n",
+       " (datetime.date(2025, 3, 31), datetime.date(2025, 6, 29)),\n",
+       " (datetime.date(2025, 6, 30), datetime.date(2025, 9, 28)),\n",
+       " (datetime.date(2025, 9, 29), datetime.date(2025, 12, 28)),\n",
+       " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -776,17 +797,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 25,
    "id": "13b500a9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Q4-23', 'Q1-24', 'Q2-24', 'Q3-24', 'Q4-24', 'Q1-25']"
+       "['Q4-24', 'Q1-25', 'Q2-25', 'Q3-25', 'Q4-25', 'Q1-26']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -808,20 +829,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 26,
    "id": "53d27ed0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2023, 12, 25), datetime.date(2023, 12, 31)),\n",
-       " (datetime.date(2024, 1, 1), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 12, 29)),\n",
-       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2024, 12, 23), datetime.date(2024, 12, 29)),\n",
+       " (datetime.date(2024, 12, 30), datetime.date(2025, 6, 29)),\n",
+       " (datetime.date(2025, 6, 30), datetime.date(2025, 12, 28)),\n",
+       " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -834,17 +855,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 27,
    "id": "77ac4f71",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['HY2-23', 'HY1-24', 'HY2-24', 'HY1-25']"
+       "['HY2-24', 'HY1-25', 'HY2-25', 'HY1-26']"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -866,19 +887,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 28,
    "id": "14b7bba4",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2023, 12, 25), datetime.date(2023, 12, 31)),\n",
-       " (datetime.date(2024, 1, 1), datetime.date(2024, 12, 29)),\n",
-       " (datetime.date(2024, 12, 30), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2024, 12, 23), datetime.date(2024, 12, 29)),\n",
+       " (datetime.date(2024, 12, 30), datetime.date(2025, 12, 28)),\n",
+       " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -891,17 +912,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 29,
    "id": "30c387ee",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['2023', '2024', '2025']"
+       "['2024', '2025', '2026']"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -922,28 +943,28 @@
     "\n",
     "### Custom Days\n",
     "\n",
-    "The most flexible of the periodicity options, this one creates bins starting on `start_date` with a number of days between them as given by the additional `custom_days` parameter."
+    "The most flexible of the periodicity options, this one creates bins starting on `start_date` with a number of days between them as given by the additional `custom_period` parameter. This may also be a sequence, such as `[5, 2]`, if used with a Monday `start_date`, would create bins of weekdays, then weekends."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 31,
    "id": "7019cac5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 12, 6), datetime.date(2024, 12, 10)),\n",
-       " (datetime.date(2024, 12, 11), datetime.date(2024, 12, 15)),\n",
-       " (datetime.date(2024, 12, 16), datetime.date(2024, 12, 20)),\n",
-       " (datetime.date(2024, 12, 21), datetime.date(2024, 12, 25)),\n",
-       " (datetime.date(2024, 12, 26), datetime.date(2024, 12, 30)),\n",
-       " (datetime.date(2024, 12, 31), datetime.date(2025, 1, 4)),\n",
-       " (datetime.date(2025, 1, 5), datetime.date(2025, 1, 5))]"
+       "[(datetime.date(2025, 2, 23), datetime.date(2025, 2, 27)),\n",
+       " (datetime.date(2025, 2, 28), datetime.date(2025, 3, 4)),\n",
+       " (datetime.date(2025, 3, 5), datetime.date(2025, 3, 9)),\n",
+       " (datetime.date(2025, 3, 10), datetime.date(2025, 3, 14)),\n",
+       " (datetime.date(2025, 3, 15), datetime.date(2025, 3, 19)),\n",
+       " (datetime.date(2025, 3, 20), datetime.date(2025, 3, 24)),\n",
+       " (datetime.date(2025, 3, 25), datetime.date(2025, 3, 25))]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -953,35 +974,65 @@
     "end_date = start_date + relativedelta(days=30)\n",
     "\n",
     "p = Period(start_date=start_date, end_date=end_date, periodicity=\"Custom Days\")\n",
-    "bins = p.get_date_bins(custom_days=5)\n",
+    "bins = p.get_date_bins(custom_period=5)\n",
     "bins"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 32,
    "id": "8d9731be",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['12/10/24',\n",
-       " '12/15/24',\n",
-       " '12/20/24',\n",
-       " '12/25/24',\n",
-       " '12/30/24',\n",
-       " '01/04/25',\n",
-       " '01/05/25']"
+       "['02/27/25',\n",
+       " '03/04/25',\n",
+       " '03/09/25',\n",
+       " '03/14/25',\n",
+       " '03/19/25',\n",
+       " '03/24/25',\n",
+       " '03/25/25']"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "p.get_period_labels(bins, \"Custom Days\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "a90fb320",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(datetime.date(2024, 12, 30), datetime.date(2025, 1, 3)),\n",
+       " (datetime.date(2025, 1, 4), datetime.date(2025, 1, 5)),\n",
+       " (datetime.date(2025, 1, 6), datetime.date(2025, 1, 10)),\n",
+       " (datetime.date(2025, 1, 11), datetime.date(2025, 1, 12))]"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Use a Monday start_date\n",
+    "start_date = datetime.date.fromisocalendar(current_year, 1, 1)\n",
+    "end_date = start_date + relativedelta(days=13)\n",
+    "\n",
+    "p = Period(start_date=start_date, end_date=end_date, periodicity=\"Custom Days\")\n",
+    "bins = p.get_date_bins(custom_period=[5, 2])  # bin by weekday, then weekend days\n",
+    "bins"
    ]
   },
   {
@@ -996,22 +1047,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 36,
    "id": "7b66131d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 15), datetime.date(2024, 1, 21)),\n",
-       " (datetime.date(2024, 1, 22), datetime.date(2024, 1, 28)),\n",
-       " (datetime.date(2024, 1, 29), datetime.date(2024, 2, 4)),\n",
-       " (datetime.date(2024, 2, 5), datetime.date(2024, 2, 11)),\n",
-       " (datetime.date(2024, 2, 12), datetime.date(2024, 2, 18)),\n",
-       " (datetime.date(2024, 2, 19), datetime.date(2024, 2, 25))]"
+       "[(datetime.date(2025, 1, 15), datetime.date(2025, 1, 21)),\n",
+       " (datetime.date(2025, 1, 22), datetime.date(2025, 1, 28)),\n",
+       " (datetime.date(2025, 1, 29), datetime.date(2025, 2, 4)),\n",
+       " (datetime.date(2025, 2, 5), datetime.date(2025, 2, 11)),\n",
+       " (datetime.date(2025, 2, 12), datetime.date(2025, 2, 18)),\n",
+       " (datetime.date(2025, 2, 19), datetime.date(2025, 2, 25))]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1027,17 +1078,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 37,
    "id": "3f682fca",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['01/21/24', '01/28/24', '02/04/24', '02/11/24', '02/18/24', '02/25/24']"
+       "['01/21/25', '01/28/25', '02/04/25', '02/11/25', '02/18/25', '02/25/25']"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1058,19 +1109,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 38,
    "id": "c7720706",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 15), datetime.date(2024, 1, 28)),\n",
-       " (datetime.date(2024, 1, 29), datetime.date(2024, 2, 11)),\n",
-       " (datetime.date(2024, 2, 12), datetime.date(2024, 2, 25))]"
+       "[(datetime.date(2025, 1, 15), datetime.date(2025, 1, 28)),\n",
+       " (datetime.date(2025, 1, 29), datetime.date(2025, 2, 11)),\n",
+       " (datetime.date(2025, 2, 12), datetime.date(2025, 2, 25))]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1083,23 +1134,201 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 39,
    "id": "4c695bbd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['01/28/24', '02/11/24', '02/25/24']"
+       "['01/28/25', '02/11/25', '02/25/25']"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "p.get_period_labels(bins, \"Biweekly\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55394445",
+   "metadata": {},
+   "source": [
+    "### Fiscal Weeks\n",
+    "\n",
+    "This periodicity option is similar to the week-grouping ISO patterns, but it doesn't strictly enforce a Monday week start. Instead, it will assume weeks start with whichever day of the week `start_date` falls on, then bin by the value or sequence given in `custom_period` (similar to how \"Custom Days\" works).\n",
+    "\n",
+    "The following examples use a Sunday week start and create \"monthly\" bins of 4 weeks, 5 weeks, then 4 weeks, repeating, then create \"quarterly\" bins of 13 weeks each, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "7d1413bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(datetime.date(2024, 12, 29), datetime.date(2025, 1, 25)),\n",
+       " (datetime.date(2025, 1, 26), datetime.date(2025, 3, 1)),\n",
+       " (datetime.date(2025, 3, 2), datetime.date(2025, 3, 29)),\n",
+       " (datetime.date(2025, 3, 30), datetime.date(2025, 4, 26)),\n",
+       " (datetime.date(2025, 4, 27), datetime.date(2025, 5, 31)),\n",
+       " (datetime.date(2025, 6, 1), datetime.date(2025, 6, 28)),\n",
+       " (datetime.date(2025, 6, 29), datetime.date(2025, 7, 26)),\n",
+       " (datetime.date(2025, 7, 27), datetime.date(2025, 8, 30)),\n",
+       " (datetime.date(2025, 8, 31), datetime.date(2025, 9, 27)),\n",
+       " (datetime.date(2025, 9, 28), datetime.date(2025, 10, 25)),\n",
+       " (datetime.date(2025, 10, 26), datetime.date(2025, 11, 29)),\n",
+       " (datetime.date(2025, 11, 30), datetime.date(2025, 12, 27))]"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Use a Sunday week start\n",
+    "start_date = datetime.date.fromisocalendar(current_year, 1, 1) - relativedelta(days=1)\n",
+    "end_date = datetime.date.fromisocalendar(current_year + 1, 1, 1) - relativedelta(days=2)\n",
+    "\n",
+    "# \"Monthly\" bins grouping weeks in a 4-5-4 pattern\n",
+    "p = Period(start_date=start_date, end_date=end_date, periodicity=\"Fiscal Weeks\")\n",
+    "bins = p.get_date_bins(custom_period=[4, 5, 4])\n",
+    "bins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "7915955b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['1 (4w)-25',\n",
+       " '2 (5w)-25',\n",
+       " '3 (4w)-25',\n",
+       " '4 (4w)-25',\n",
+       " '5 (5w)-25',\n",
+       " '6 (4w)-25',\n",
+       " '7 (4w)-25',\n",
+       " '8 (5w)-25',\n",
+       " '9 (4w)-25',\n",
+       " '10 (4w)-25',\n",
+       " '11 (5w)-25',\n",
+       " '12 (4w)-25']"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p.get_period_labels(bins)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "180bf104",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(datetime.date(2024, 12, 29), datetime.date(2025, 3, 29)),\n",
+       " (datetime.date(2025, 3, 30), datetime.date(2025, 6, 28)),\n",
+       " (datetime.date(2025, 6, 29), datetime.date(2025, 9, 27)),\n",
+       " (datetime.date(2025, 9, 28), datetime.date(2025, 12, 27))]"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# \"Quarterly\" bins of 13 weeks each\n",
+    "p = Period(start_date=start_date, end_date=end_date, periodicity=\"Fiscal Weeks\")\n",
+    "bins = p.get_date_bins(custom_period=13)\n",
+    "bins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "b5c3efd5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['1 (13w)-25', '2 (13w)-25', '3 (13w)-25', '4 (13w)-25']"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p.get_period_labels(bins)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c94c68a5",
+   "metadata": {},
+   "source": [
+    "If the user does need a \"stub\" period at the beginning or end of the period, they can include the shorter value in the sequence, but must extend the sequence so the short value doesn't repeat. For example, the user defines months in the 4-5-4 pattern, and is two weeks into January (a 4 week month). They want to generate date bins for the rest of the year, starting from the current date. They would need to use a `custom_period` pattern of: `[2, 5, 4, 4, 5, 4, 4, 5, 4, 4, 5, 4]` to correctly generate the bins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "7128b2de",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(datetime.date(2025, 1, 12), datetime.date(2025, 1, 25)),\n",
+       " (datetime.date(2025, 1, 26), datetime.date(2025, 3, 1)),\n",
+       " (datetime.date(2025, 3, 2), datetime.date(2025, 3, 29)),\n",
+       " (datetime.date(2025, 3, 30), datetime.date(2025, 4, 26)),\n",
+       " (datetime.date(2025, 4, 27), datetime.date(2025, 5, 31)),\n",
+       " (datetime.date(2025, 6, 1), datetime.date(2025, 6, 28)),\n",
+       " (datetime.date(2025, 6, 29), datetime.date(2025, 7, 26)),\n",
+       " (datetime.date(2025, 7, 27), datetime.date(2025, 8, 30)),\n",
+       " (datetime.date(2025, 8, 31), datetime.date(2025, 9, 27)),\n",
+       " (datetime.date(2025, 9, 28), datetime.date(2025, 10, 25)),\n",
+       " (datetime.date(2025, 10, 26), datetime.date(2025, 11, 29)),\n",
+       " (datetime.date(2025, 11, 30), datetime.date(2025, 12, 27))]"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Use a Sunday week start, but \n",
+    "start_date = datetime.date.fromisocalendar(current_year, 1, 1) - relativedelta(days=1) + relativedelta(weeks=2)\n",
+    "end_date = datetime.date.fromisocalendar(current_year + 1, 1, 1) - relativedelta(days=2)\n",
+    "\n",
+    "# \"Monthly\" bins grouping weeks in a 4-5-4 pattern, but with a 2-week stub period for January\n",
+    "p = Period(start_date=start_date, end_date=end_date, periodicity=\"Fiscal Weeks\")\n",
+    "bins = p.get_date_bins(custom_period=[2, 5, 4, 4, 5, 4, 4, 5, 4, 4, 5, 4])\n",
+    "bins"
    ]
   },
   {
@@ -1114,22 +1343,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 54,
    "id": "2194d6fb",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 15), datetime.date(2024, 1, 31)),\n",
-       " (datetime.date(2024, 2, 1), datetime.date(2024, 2, 29)),\n",
-       " (datetime.date(2024, 3, 1), datetime.date(2024, 3, 31)),\n",
-       " (datetime.date(2024, 4, 1), datetime.date(2024, 4, 30)),\n",
-       " (datetime.date(2024, 5, 1), datetime.date(2024, 5, 31)),\n",
-       " (datetime.date(2024, 6, 1), datetime.date(2024, 6, 14))]"
+       "[(datetime.date(2025, 1, 15), datetime.date(2025, 1, 31)),\n",
+       " (datetime.date(2025, 2, 1), datetime.date(2025, 2, 28)),\n",
+       " (datetime.date(2025, 3, 1), datetime.date(2025, 3, 31)),\n",
+       " (datetime.date(2025, 4, 1), datetime.date(2025, 4, 30)),\n",
+       " (datetime.date(2025, 5, 1), datetime.date(2025, 5, 31)),\n",
+       " (datetime.date(2025, 6, 1), datetime.date(2025, 6, 14))]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1145,17 +1374,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 55,
    "id": "17411a22",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Jan-24', 'Feb-24', 'Mar-24', 'Apr-24', 'May-24', 'Jun-24']"
+       "['Jan-25', 'Feb-25', 'Mar-25', 'Apr-25', 'May-25', 'Jun-25']"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1176,21 +1405,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 56,
    "id": "5dbba314",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 15), datetime.date(2024, 2, 14)),\n",
-       " (datetime.date(2024, 2, 15), datetime.date(2024, 3, 14)),\n",
-       " (datetime.date(2024, 3, 15), datetime.date(2024, 4, 14)),\n",
-       " (datetime.date(2024, 4, 15), datetime.date(2024, 5, 14)),\n",
-       " (datetime.date(2024, 5, 15), datetime.date(2024, 6, 14))]"
+       "[(datetime.date(2025, 1, 15), datetime.date(2025, 2, 14)),\n",
+       " (datetime.date(2025, 2, 15), datetime.date(2025, 3, 14)),\n",
+       " (datetime.date(2025, 3, 15), datetime.date(2025, 4, 14)),\n",
+       " (datetime.date(2025, 4, 15), datetime.date(2025, 5, 14)),\n",
+       " (datetime.date(2025, 5, 15), datetime.date(2025, 6, 14))]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1206,17 +1435,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 57,
    "id": "84bb606c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Feb-24', 'Mar-24', 'Apr-24', 'May-24', 'Jun-24']"
+       "['Feb-25', 'Mar-25', 'Apr-25', 'May-25', 'Jun-25']"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1237,21 +1466,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 58,
    "id": "f6c01901",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 15), datetime.date(2024, 3, 31)),\n",
-       " (datetime.date(2024, 4, 1), datetime.date(2024, 6, 30)),\n",
-       " (datetime.date(2024, 7, 1), datetime.date(2024, 9, 30)),\n",
-       " (datetime.date(2024, 10, 1), datetime.date(2024, 12, 31)),\n",
-       " (datetime.date(2025, 1, 1), datetime.date(2025, 3, 31))]"
+       "[(datetime.date(2025, 1, 15), datetime.date(2025, 3, 31)),\n",
+       " (datetime.date(2025, 4, 1), datetime.date(2025, 6, 30)),\n",
+       " (datetime.date(2025, 7, 1), datetime.date(2025, 9, 30)),\n",
+       " (datetime.date(2025, 10, 1), datetime.date(2025, 12, 31)),\n",
+       " (datetime.date(2026, 1, 1), datetime.date(2026, 3, 31))]"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1267,17 +1496,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 59,
    "id": "103aa83d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['03-24Q', '06-24Q', '09-24Q', '12-24Q', '03-25Q']"
+       "['03-25Q', '06-25Q', '09-25Q', '12-25Q', '03-26Q']"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1298,20 +1527,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 60,
    "id": "0429ef96",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 11, 15), datetime.date(2025, 2, 14)),\n",
-       " (datetime.date(2025, 2, 15), datetime.date(2025, 5, 14)),\n",
-       " (datetime.date(2025, 5, 15), datetime.date(2025, 8, 14)),\n",
-       " (datetime.date(2025, 8, 15), datetime.date(2025, 11, 14))]"
+       "[(datetime.date(2025, 11, 15), datetime.date(2026, 2, 14)),\n",
+       " (datetime.date(2026, 2, 15), datetime.date(2026, 5, 14)),\n",
+       " (datetime.date(2026, 5, 15), datetime.date(2026, 8, 14)),\n",
+       " (datetime.date(2026, 8, 15), datetime.date(2026, 11, 14))]"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1327,17 +1556,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 61,
    "id": "58d7f70f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['02-25Q', '05-25Q', '08-25Q', '11-25Q']"
+       "['02-26Q', '05-26Q', '08-26Q', '11-26Q']"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1358,19 +1587,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 62,
    "id": "ccea70a6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 1, 15), datetime.date(2024, 12, 31)),\n",
-       " (datetime.date(2025, 1, 1), datetime.date(2025, 12, 31)),\n",
-       " (datetime.date(2026, 1, 1), datetime.date(2026, 12, 31))]"
+       "[(datetime.date(2025, 1, 15), datetime.date(2025, 12, 31)),\n",
+       " (datetime.date(2026, 1, 1), datetime.date(2026, 12, 31)),\n",
+       " (datetime.date(2027, 1, 1), datetime.date(2027, 12, 31))]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1386,17 +1615,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 63,
    "id": "aec63b27",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['12/31/24', '12/31/25', '12/31/26']"
+       "['12/31/25', '12/31/26', '12/31/27']"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1417,18 +1646,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 64,
    "id": "7553b13d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2024, 7, 15), datetime.date(2025, 7, 14)),\n",
-       " (datetime.date(2025, 7, 15), datetime.date(2026, 7, 14))]"
+       "[(datetime.date(2025, 7, 15), datetime.date(2026, 7, 14)),\n",
+       " (datetime.date(2026, 7, 15), datetime.date(2027, 7, 14))]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1444,17 +1673,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 65,
    "id": "90fdfb1d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['07/14/25', '07/14/26']"
+       "['07/14/26', '07/14/27']"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1480,7 +1709,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/date_binning.ipynb
+++ b/date_binning.ipynb
@@ -21,10 +21,10 @@
     "- \"ISO Quarter (13 Weeks)\": quarterly bins of 13 ISO week periods. Quarter 1 is weeks 01-13, quarter 2 is weeks 14-26, etc.\n",
     "- \"ISO Semiannual (26 Weeks)\": semiannual bins of 26 ISO week periods. The first period is weeks 01-26 and second is weeks 27 to either 52 or 53, depending on the year\n",
     "- \"ISO Annual\": bins of full ISO years. If `start_date` is not the first day of the ISO year, the first bin will be a partial year\n",
-    "- \"Custom Days\": bins starting on `start_date` with a number of days between them as given by the `custom_period` parameter in `get_date_bins` (this may be a single integer or a sequence that's cycled over)\n",
+    "- \"Custom Days\": bins starting on `start_date` with a number of days between them as given by the `custom_period` parameter in `get_date_bins` (this may be a single integer or a sequence that's cycled over). The default is 1 to create daily bins\n",
     "- \"Weekly\": weekly bins starting on `start_date`'s weekday\n",
     "- \"Biweekly\": bins of 2-week periods, starting on `start_date`'s weekday\n",
-    "- \"Fiscal Weeks\": bins starting on `start_date` with a number of weeks between them as given by the `custom_period` parameter in `get_date_bins` (this may be a single integer, like 13 weeks, or a sequence such as [4, 5, 4]). This option is similar to the ISO patterns, but counts weeks starting with the given `start_date`, regardless of which day of the week it is\n",
+    "- \"Fiscal Weeks\": bins starting on `start_date` with a number of weeks between them as given by the `custom_period` parameter in `get_date_bins` (this may be a single integer, like 13 weeks, or a sequence such as [4, 5, 4]). This option is similar to the ISO patterns, but counts weeks starting with the given `start_date`, regardless of which day of the week it is. The default for `custom_period` is 1 to create weekly bins\n",
     "- \"Calendar Month\": bins by calendar month\n",
     "- \"Monthly\": monthly bins starting on `start_date`\n",
     "- \"Calendar Quarter\": bins of 3-month periods based on a calendar year (Jan-Mar, Apr-Jun, etc.)\n",
@@ -76,17 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "d3e97098",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "d = Period().get_date_bins(start_date, end_date, \"ISO Week\", inclusive=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "688c0f15",
    "metadata": {},
    "outputs": [
@@ -147,7 +137,7 @@
        " (datetime.date(2025, 12, 22), datetime.date(2025, 12, 28))]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -177,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "id": "44f3f617",
    "metadata": {},
    "outputs": [
@@ -190,7 +180,7 @@
        " (datetime.date(2025, 1, 20), datetime.date(2025, 1, 24))]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -219,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "94eeaf95",
    "metadata": {},
    "outputs": [
@@ -229,7 +219,7 @@
        "['Week 1-25', 'Week 2-25', 'Week 3-25', 'Week 4-25']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -241,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "4c2529c0",
    "metadata": {},
    "outputs": [
@@ -251,7 +241,7 @@
        "['Jan-05', 'Jan-12', 'Jan-19', 'Jan-24']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -278,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "d1136250",
    "metadata": {},
    "outputs": [
@@ -291,7 +281,7 @@
        " (datetime.date(2025, 9, 29), datetime.date(2025, 12, 28))]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -311,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "id": "15c1a179",
    "metadata": {},
    "outputs": [
@@ -321,7 +311,7 @@
        "['Q1-25', 'Q2-25', 'Q3-25', 'Q4-25']"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -344,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "4a8a8486",
    "metadata": {},
    "outputs": [
@@ -361,7 +351,7 @@
        "              Decimal('1299.999999999999999999999995'))])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -392,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "7e9e321b",
    "metadata": {},
    "outputs": [
@@ -415,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "id": "67766685",
    "metadata": {},
    "outputs": [
@@ -452,7 +442,7 @@
        " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "id": "3c496396",
    "metadata": {},
    "outputs": [
@@ -502,7 +492,7 @@
        " 'Weeks 1-1 26']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -524,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "id": "b99eb5d2",
    "metadata": {},
    "outputs": [
@@ -548,7 +538,7 @@
        " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -561,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
    "id": "52d5b805",
    "metadata": {},
    "outputs": [
@@ -585,7 +575,7 @@
        " 'Jan (4w)-26']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -607,7 +597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "id": "34a02c5f",
    "metadata": {},
    "outputs": [
@@ -630,7 +620,7 @@
        " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -643,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 15,
    "id": "32524f3c",
    "metadata": {},
    "outputs": [
@@ -666,7 +656,7 @@
        " 'Jan (4w)-26']"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -688,7 +678,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 16,
    "id": "ea0e27dd",
    "metadata": {},
    "outputs": [
@@ -711,7 +701,7 @@
        " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -724,7 +714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 17,
    "id": "6e4c9559",
    "metadata": {},
    "outputs": [
@@ -747,7 +737,7 @@
        " 'Jan (4w)-26']"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -769,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 18,
    "id": "1159bde4",
    "metadata": {},
    "outputs": [
@@ -784,7 +774,7 @@
        " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -797,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 19,
    "id": "13b500a9",
    "metadata": {},
    "outputs": [
@@ -807,7 +797,7 @@
        "['Q4-24', 'Q1-25', 'Q2-25', 'Q3-25', 'Q4-25', 'Q1-26']"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -829,7 +819,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 20,
    "id": "53d27ed0",
    "metadata": {},
    "outputs": [
@@ -842,7 +832,7 @@
        " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -855,7 +845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 21,
    "id": "77ac4f71",
    "metadata": {},
    "outputs": [
@@ -865,7 +855,7 @@
        "['HY2-24', 'HY1-25', 'HY2-25', 'HY1-26']"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -887,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "id": "14b7bba4",
    "metadata": {},
    "outputs": [
@@ -899,7 +889,7 @@
        " (datetime.date(2025, 12, 29), datetime.date(2026, 1, 4))]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -912,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 23,
    "id": "30c387ee",
    "metadata": {},
    "outputs": [
@@ -922,7 +912,7 @@
        "['2024', '2025', '2026']"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -943,35 +933,68 @@
     "\n",
     "### Custom Days\n",
     "\n",
-    "The most flexible of the periodicity options, this one creates bins starting on `start_date` with a number of days between them as given by the additional `custom_period` parameter. This may also be a sequence, such as `[5, 2]`, if used with a Monday `start_date`, would create bins of weekdays, then weekends."
+    "The most flexible of the periodicity options, this one creates bins starting on `start_date` with a number of days between them as given by the additional `custom_period` parameter. This may also be a sequence. The second example uses a `custom_period` of `[5, 2]` and a Monday `start_date` to create bins of weekdays, then weekends. The default value for `custom_period` is `1`, which creates bins spanning one day each."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 26,
    "id": "7019cac5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(datetime.date(2025, 2, 23), datetime.date(2025, 2, 27)),\n",
-       " (datetime.date(2025, 2, 28), datetime.date(2025, 3, 4)),\n",
-       " (datetime.date(2025, 3, 5), datetime.date(2025, 3, 9)),\n",
-       " (datetime.date(2025, 3, 10), datetime.date(2025, 3, 14)),\n",
-       " (datetime.date(2025, 3, 15), datetime.date(2025, 3, 19)),\n",
-       " (datetime.date(2025, 3, 20), datetime.date(2025, 3, 24)),\n",
-       " (datetime.date(2025, 3, 25), datetime.date(2025, 3, 25))]"
+       "[(datetime.date(2025, 2, 25), datetime.date(2025, 2, 25)),\n",
+       " (datetime.date(2025, 2, 26), datetime.date(2025, 2, 26)),\n",
+       " (datetime.date(2025, 2, 27), datetime.date(2025, 2, 27)),\n",
+       " (datetime.date(2025, 2, 28), datetime.date(2025, 2, 28)),\n",
+       " (datetime.date(2025, 3, 1), datetime.date(2025, 3, 1)),\n",
+       " (datetime.date(2025, 3, 2), datetime.date(2025, 3, 2)),\n",
+       " (datetime.date(2025, 3, 3), datetime.date(2025, 3, 3))]"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# Daily bins (default)\n",
     "start_date = datetime.datetime.now().date()\n",
-    "end_date = start_date + relativedelta(days=30)\n",
+    "end_date = start_date + relativedelta(days=6)\n",
+    "\n",
+    "p = Period(start_date=start_date, end_date=end_date, periodicity=\"Custom Days\")\n",
+    "bins = p.get_date_bins()\n",
+    "bins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "ba84847d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(datetime.date(2025, 2, 25), datetime.date(2025, 3, 1)),\n",
+       " (datetime.date(2025, 3, 2), datetime.date(2025, 3, 6)),\n",
+       " (datetime.date(2025, 3, 7), datetime.date(2025, 3, 11)),\n",
+       " (datetime.date(2025, 3, 12), datetime.date(2025, 3, 16)),\n",
+       " (datetime.date(2025, 3, 17), datetime.date(2025, 3, 21)),\n",
+       " (datetime.date(2025, 3, 22), datetime.date(2025, 3, 26))]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Bins of 5 days each\n",
+    "start_date = datetime.datetime.now().date()\n",
+    "end_date = start_date + relativedelta(days=29)\n",
     "\n",
     "p = Period(start_date=start_date, end_date=end_date, periodicity=\"Custom Days\")\n",
     "bins = p.get_date_bins(custom_period=5)\n",
@@ -980,23 +1003,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 28,
    "id": "8d9731be",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['02/27/25',\n",
-       " '03/04/25',\n",
-       " '03/09/25',\n",
-       " '03/14/25',\n",
-       " '03/19/25',\n",
-       " '03/24/25',\n",
-       " '03/25/25']"
+       "['03/01/25', '03/06/25', '03/11/25', '03/16/25', '03/21/25', '03/26/25']"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1007,7 +1024,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 29,
    "id": "a90fb320",
    "metadata": {},
    "outputs": [
@@ -1020,13 +1037,13 @@
        " (datetime.date(2025, 1, 11), datetime.date(2025, 1, 12))]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Use a Monday start_date\n",
+    "# Bins of weekdays followed by weekend days (uses a Monday start_date)\n",
     "start_date = datetime.date.fromisocalendar(current_year, 1, 1)\n",
     "end_date = start_date + relativedelta(days=13)\n",
     "\n",
@@ -1047,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 30,
    "id": "7b66131d",
    "metadata": {},
    "outputs": [
@@ -1062,7 +1079,7 @@
        " (datetime.date(2025, 2, 19), datetime.date(2025, 2, 25))]"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1078,7 +1095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 31,
    "id": "3f682fca",
    "metadata": {},
    "outputs": [
@@ -1088,7 +1105,7 @@
        "['01/21/25', '01/28/25', '02/04/25', '02/11/25', '02/18/25', '02/25/25']"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1109,7 +1126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 32,
    "id": "c7720706",
    "metadata": {},
    "outputs": [
@@ -1121,7 +1138,7 @@
        " (datetime.date(2025, 2, 12), datetime.date(2025, 2, 25))]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1134,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 33,
    "id": "4c695bbd",
    "metadata": {},
    "outputs": [
@@ -1144,7 +1161,7 @@
        "['01/28/25', '02/11/25', '02/25/25']"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1162,12 +1179,12 @@
     "\n",
     "This periodicity option is similar to the week-grouping ISO patterns, but it doesn't strictly enforce a Monday week start. Instead, it will assume weeks start with whichever day of the week `start_date` falls on, then bin by the value or sequence given in `custom_period` (similar to how \"Custom Days\" works).\n",
     "\n",
-    "The following examples use a Sunday week start and create \"monthly\" bins of 4 weeks, 5 weeks, then 4 weeks, repeating, then create \"quarterly\" bins of 13 weeks each, respectively."
+    "The following examples use a Sunday week start and create \"monthly\" bins of 4 weeks, 5 weeks, then 4 weeks, repeating, then \"quarterly\" bins of 13 weeks each, respectively. The default value for `custom_period` is `1`, which creates weekly bins (same result as using a \"Weekly\" periodicity)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 34,
    "id": "7d1413bc",
    "metadata": {},
    "outputs": [
@@ -1188,7 +1205,7 @@
        " (datetime.date(2025, 11, 30), datetime.date(2025, 12, 27))]"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1206,7 +1223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 35,
    "id": "7915955b",
    "metadata": {},
    "outputs": [
@@ -1227,7 +1244,7 @@
        " '12 (4w)-25']"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1238,7 +1255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 36,
    "id": "180bf104",
    "metadata": {},
    "outputs": [
@@ -1251,7 +1268,7 @@
        " (datetime.date(2025, 9, 28), datetime.date(2025, 12, 27))]"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1265,7 +1282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 37,
    "id": "b5c3efd5",
    "metadata": {},
    "outputs": [
@@ -1275,7 +1292,7 @@
        "['1 (13w)-25', '2 (13w)-25', '3 (13w)-25', '4 (13w)-25']"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1294,7 +1311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 38,
    "id": "7128b2de",
    "metadata": {},
    "outputs": [
@@ -1315,7 +1332,7 @@
        " (datetime.date(2025, 11, 30), datetime.date(2025, 12, 27))]"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1343,7 +1360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 39,
    "id": "2194d6fb",
    "metadata": {},
    "outputs": [
@@ -1358,7 +1375,7 @@
        " (datetime.date(2025, 6, 1), datetime.date(2025, 6, 14))]"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1374,7 +1391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 40,
    "id": "17411a22",
    "metadata": {},
    "outputs": [
@@ -1384,7 +1401,7 @@
        "['Jan-25', 'Feb-25', 'Mar-25', 'Apr-25', 'May-25', 'Jun-25']"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1405,7 +1422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 41,
    "id": "5dbba314",
    "metadata": {},
    "outputs": [
@@ -1419,7 +1436,7 @@
        " (datetime.date(2025, 5, 15), datetime.date(2025, 6, 14))]"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1435,7 +1452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 42,
    "id": "84bb606c",
    "metadata": {},
    "outputs": [
@@ -1445,7 +1462,7 @@
        "['Feb-25', 'Mar-25', 'Apr-25', 'May-25', 'Jun-25']"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1466,7 +1483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 43,
    "id": "f6c01901",
    "metadata": {},
    "outputs": [
@@ -1480,7 +1497,7 @@
        " (datetime.date(2026, 1, 1), datetime.date(2026, 3, 31))]"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1496,7 +1513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 44,
    "id": "103aa83d",
    "metadata": {},
    "outputs": [
@@ -1506,7 +1523,7 @@
        "['03-25Q', '06-25Q', '09-25Q', '12-25Q', '03-26Q']"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1527,7 +1544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 45,
    "id": "0429ef96",
    "metadata": {},
    "outputs": [
@@ -1540,7 +1557,7 @@
        " (datetime.date(2026, 8, 15), datetime.date(2026, 11, 14))]"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1556,7 +1573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 46,
    "id": "58d7f70f",
    "metadata": {},
    "outputs": [
@@ -1566,7 +1583,7 @@
        "['02-26Q', '05-26Q', '08-26Q', '11-26Q']"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1587,7 +1604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 47,
    "id": "ccea70a6",
    "metadata": {},
    "outputs": [
@@ -1599,7 +1616,7 @@
        " (datetime.date(2027, 1, 1), datetime.date(2027, 12, 31))]"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1615,7 +1632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 48,
    "id": "aec63b27",
    "metadata": {},
    "outputs": [
@@ -1625,7 +1642,7 @@
        "['12/31/25', '12/31/26', '12/31/27']"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1646,7 +1663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 49,
    "id": "7553b13d",
    "metadata": {},
    "outputs": [
@@ -1657,7 +1674,7 @@
        " (datetime.date(2026, 7, 15), datetime.date(2027, 7, 14))]"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1673,7 +1690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 50,
    "id": "90fdfb1d",
    "metadata": {},
    "outputs": [
@@ -1683,7 +1700,7 @@
        "['07/14/26', '07/14/27']"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/forecast/date_binning.py
+++ b/forecast/date_binning.py
@@ -27,7 +27,7 @@ class Period:
 			"ISO Semiannual (26 Weeks)": [1, 27],
 			"ISO Annual": [1],
 			# Calendar pattern: (date part to increment, step to increment by)
-			# "Custom Days" added in get_date_bins as needed
+			# "Custom Days" and "Fiscal Weeks" added in get_date_bins as needed
 			"Weekly": ("weeks", 1),
 			"Biweekly": ("weeks", 2),
 			"Calendar Month": ("months", 1),
@@ -129,39 +129,42 @@ class Period:
 		:return: list bin start dates
 		"""
 		period, delta = self.date_math_patterns[periodicity]
+		delta = [delta] if isinstance(delta, int) else delta
+		seq = cycle(delta)
+
 		r = []
 
 		if period == "days":
 			while start_date < end_date:
 				r.append(start_date)
-				start_date += relativedelta(days=delta)
+				start_date += relativedelta(days=next(seq))
 
 		elif period == "weeks":
 			while start_date < end_date:
 				r.append(start_date)
-				start_date += relativedelta(weeks=delta)
+				start_date += relativedelta(weeks=next(seq))
 
 		# For "Calendar" periodicities, adjust start_date before incrementing if not first day of period
 		elif period == "months":
 			if periodicity == "Calendar Month" and start_date.day != 1:
 				r.append(start_date)
-				start_date = start_date.replace(day=1) + relativedelta(months=delta)
+				start_date = start_date.replace(day=1) + relativedelta(months=next(seq))
 			elif periodicity == "Calendar Quarter":
 				r.append(start_date)
-				start_date = self._get_current_quarter_start(start_date) + relativedelta(months=delta)
+				start_date = self._get_current_quarter_start(start_date) + relativedelta(months=next(seq))
 
 			while start_date < end_date:
 				r.append(start_date)
-				start_date += relativedelta(months=delta)
+				start_date += relativedelta(months=next(seq))
 
 		elif period == "years":
 			if periodicity == "Calendar Year" and (start_date.day != 1 or start_date.month != 1):
 				r.append(start_date)
-				start_date = start_date.replace(month=1, day=1) + relativedelta(years=delta)
+				start_date = start_date.replace(month=1, day=1) + relativedelta(years=next(seq))
 
 			while start_date < end_date:
 				r.append(start_date)
-				start_date += relativedelta(years=delta)
+				start_date += relativedelta(years=next(seq))
 
 		return r
 
@@ -186,7 +189,7 @@ class Period:
 		end_date: datetime.date | None = None,
 		periodicity: str | None = None,
 		inclusive: bool = True,
-		custom_days: int | None = None,
+		custom_period: int | list[int] | None = None,
 	) -> list[tuple[datetime.date, datetime.date]]:
 		"""
 		Gets the starting dates for all periods falling within the time span from `start_date` to
@@ -207,29 +210,33 @@ class Period:
 		    - "ISO Week" (default): weekly bins starting on a Monday
 		    - "ISO Biweekly": bins of 2 ISO week periods
 		    - "ISO Month (4 Weeks)": monthly bins of 4 ISO week periods assuming ISO weeks are put
-		            in months with a pattern of 4 weeks each
+		    in months with a pattern of 4 weeks each
 		    - "ISO Month (4 + 5 + 4)": monthly bins of ISO week periods assuming ISO weeks are put
-		            in months with a pattern of 4 weeks, 5 weeks, then 4 weeks, repeating
+		    in months with a pattern of 4 weeks, 5 weeks, then 4 weeks, repeating
 		    - "ISO Month (4 + 4 + 5)": monthly bins of ISO week periods assuming ISO weeks are put
-		            in months with a pattern of 4 weeks, 4 weeks, then 5 weeks, repeating
+		    n months with a pattern of 4 weeks, 4 weeks, then 5 weeks, repeating
 		    - "ISO Quarter (13 Weeks)": quarterly bins of 13 ISO week periods
 		    - "ISO Semiannual (26 Weeks)": semiannual bins of 26 ISO week periods
 		    - "ISO Annual": bins by ISO year
 		    - "Custom Days": bins starting on `start_date` with a number of days between them as
-		        given by `custom_days`
+		    given by `custom_period` (may be a single integer or sequence that's cycled over)
 		    - "Weekly": weekly bins starting on `start_date`'s weekday
 		    - "Biweekly": bins of 2-week periods, starting on `start_date`'s weekday
+		    - "Fiscal Weeks": bins starting on `start_date` with a number of weeks between them as
+		    given by `custom_period` (this may be a single integer or a sequence)
 		    - "Calendar Month": bins by calendar month
-		        - "Monthly": monthly bins starting on `start_date`
-		    - "Calendar Quarter": bins of 3-month periods based on a calendar year (Jan-Mar, Apr-Jun, etc.)
-		        - "Quarterly": bins of 3-month periods starting on `start_date`
+		    - "Monthly": monthly bins starting on `start_date`
+		    - "Calendar Quarter": bins of 3-month periods based on a calendar year (Jan-Mar, Apr-
+		    Jun, etc.)
+		    - "Quarterly": bins of 3-month periods starting on `start_date`
 		    - "Calendar Year": calendar year bins (Jan-Dec)
 		    - "Annually": yearly bins starting from `start_date`
 		    - "Entire Period": one bin from `start_date` to either `end_date` (if
-		        inclusive=True) or the day prior to `end_date` (if inclusive=False)
-		:param inclusive:if resulting bins include the end_date (inclusive=True) or ends the day
+		    inclusive=True) or the day prior to `end_date` (if inclusive=False)
+		:param inclusive: if resulting bins include the end_date (inclusive=True) or ends the day
 		before (inclusive=False)
-		:param custom_days: number of days per bin, only applicable only if "Custom Days"
+		:param custom_period: a single or sequence of integers that specifies the days (for
+		"Custom Days") or weeks (for "Fiscal Weeks") in a bin
 		periodicity is selected
 		:return: list of tuples in form `(datetime.date object, datetime.date object)`
 		"""
@@ -246,15 +253,27 @@ class Period:
 		if end_date <= start_date:
 			raise ValueError("End date must be after start date.")
 
-		if periodicity == "Custom Days" and (not isinstance(custom_days, int) or custom_days < 1):
-			raise ValueError("Custom Days periodicity requires an integer value > 0 for custom_days.")
+		if periodicity in ["Custom Days", "Fiscal Weeks"]:
+			# and (not isinstance(custom_period, int) or custom_period < 1):
+			if not custom_period or not (isinstance(custom_period, int) or isinstance(custom_period, list)):
+				raise ValueError(f"{periodicity} periodicity requires a custom_period.")
+
+			if isinstance(custom_period, int) and custom_period < 1:
+				raise ValueError(f"{periodicity} periodicity requires an integer value > 0 for custom_period.")
+
+			if isinstance(custom_period, list) and (
+				not all([isinstance(n, int) for n in custom_period]) or any([n < 1 for n in custom_period])
+			):
+				raise ValueError(f"{periodicity} periodicity requires integer values > 0 for custom_period.")
 
 		effective_end_date = end_date if not inclusive else end_date + relativedelta(days=1)
-		periodicity = self.periodicity if not periodicity else periodicity
 		is_iso = "iso" in periodicity.lower()
 
 		if periodicity == "Custom Days":
-			self.date_math_patterns.update({"Custom Days": ("days", custom_days)})
+			self.date_math_patterns.update({"Custom Days": ("days", custom_period)})
+
+		if periodicity == "Fiscal Weeks":
+			self.date_math_patterns.update({"Fiscal Weeks": ("weeks", custom_period)})
 
 		if periodicity == "Entire Period":
 			return [(start_date, end_date if inclusive else end_date - relativedelta(days=1))]
@@ -272,7 +291,7 @@ class Period:
 		self,
 		bins: list[tuple[datetime.date, datetime.date]],
 		periodicity: str = "ISO Week",
-		custom_days: int | None = None,
+		custom_period: int | list[int] | None = None,
 	) -> list[tuple[datetime.date, datetime.date]]:
 		"""
 		Converts date bins from their original periodicity into bins for new given `periodicity`
@@ -281,6 +300,8 @@ class Period:
 		:param bins: list of tuples in form `(datetime.date object, datetime.date object)`
 		:param periodicity: str; how to determine the periods within the time span from
 		`start_date` to `end_date`. Default is "ISO Week"
+		:param custom_period: a single or sequence of integers that specifies the days (for
+		"Custom Days") or weeks (for "Fiscal Weeks") in a bin
 		:return: list of tuples in form `(datetime.date object, datetime.date object)`
 		"""
 		if not bins:
@@ -292,7 +313,7 @@ class Period:
 			end_date=end_date,
 			periodicity=periodicity,
 			inclusive=True,
-			custom_days=custom_days,
+			custom_period=custom_period,
 		)
 
 	def redistribute_data(
@@ -300,7 +321,7 @@ class Period:
 		data,
 		bins: list[tuple[datetime.date, datetime.date]],
 		periodicity: str = "ISO Week",
-		custom_days: int | None = None,
+		custom_period: int | list[int] | None = None,
 	):
 		"""
 		Redistributes numeric `data` for the periods specified by `bins` into new date periods
@@ -313,6 +334,8 @@ class Period:
 		represent the date ranges aligning with the given numeric data
 		:param periodicity: str; how to determine the periods within the same time span as `bins`.
 		Default is "ISO Week"
+		:param custom_period: a single or sequence of integers that specifies the days (for
+		"Custom Days") or weeks (for "Fiscal Weeks") in a bin
 		:return: OrderedDict; the keys are tuples of datetime.date objects representing the bins
 		for the new periodicity, the values are the redistributed numeric data in Decimal format
 		"""
@@ -326,7 +349,7 @@ class Period:
 			d_per_day += [d / n] * n
 
 		# Get new bins
-		new_bins = self.convert_dates(bins, periodicity, custom_days)
+		new_bins = self.convert_dates(bins, periodicity, custom_period)
 
 		# Get number of days of new bins and convert to cumulative indices
 		indices = accumulate([(b[1] - b[0]).days + 1 for b in new_bins], initial=0)
@@ -341,7 +364,7 @@ class Period:
 		bins: list[tuple[datetime.date, datetime.date]],
 		periodicity: str | None = None,
 		date_format_string: str = "",
-		use_bin_start_date_for_label: bool = True,
+		use_bin_start_date_for_label: bool | None = None,
 	) -> list[str]:
 		"""
 		Returns the formatted date labels for the provided bins.
@@ -352,11 +375,10 @@ class Period:
 		label format for the given `bins`. Uses the class periodicity as a fallback
 		:param date_format_string: a custom date format string to apply to the bins to generate
 		labels. Can support any Python strftime formatters
-		:param use_bin_start_date_for_label: only applies if `date_format_string` provided.
-		Date bins are pairs of datetime.date objects that represent the start date and end date of
-		each bin. If True, the custom format string is applied to the start date of the pair, if
-		False, it's applied the the end date. If `date_format_string` isn't provided, the labels
-		use the start date for ISO-based periodicities and the end date for Calendar-based ones
+		:param use_bin_start_date_for_label: Date bins are pairs of datetime.date objects that
+		represent the start date and end date of each bin. If True, it uses the bin's start date
+		to create the label, if False it uses the bin's end date. If None, it uses the start date
+		for any ISO-based periodicity and it uses the end date for all other periodicity options
 		:return: the labels for the given date bins
 
 		If `date_format_string` isn't provided, function returns the following built-in formats by
@@ -372,6 +394,8 @@ class Period:
 		- "Custom Days": "MM/DD/YY"
 		- "Weekly": "MM/DD/YY"
 		- "Biweekly": "MM/DD/YY"
+		- "Fiscal Weeks": "I (Nw)-YY" (where I is the 1-based bin index, N is the number of weeks
+		in the bin group), the year is calculated per `use_bin_start_date_for_label`
 		- "Calendar Month": "MMM-YY"
 		- "Calendar Quarter": "MM-YYQ"
 		- "Calendar Year": "MM/DD/YY"
@@ -379,13 +403,18 @@ class Period:
 		- "Entire Period": "MM/DD/YY-MM/DD/YY"
 		"""
 		periodicity = periodicity or self.periodicity
-		date_idx = int(not use_bin_start_date_for_label)
+		is_iso = "iso" in periodicity.lower()
+		date_idx = (
+			int(not is_iso)
+			if use_bin_start_date_for_label is None
+			else int(not use_bin_start_date_for_label)
+		)
 
 		if not bins:
 			return []
 
-		if "iso" in periodicity.lower():
-			iso_data: list[tuple[int, int]] = [self._get_iso_week_and_year(p[0]) for p in bins]
+		if is_iso:
+			iso_data: list[tuple[int, int]] = [self._get_iso_week_and_year(p[date_idx]) for p in bins]
 
 		if date_format_string:
 			return [p[date_idx].strftime(date_format_string) for p in bins]
@@ -771,15 +800,15 @@ class Period:
 			p = bins[0]
 			return [f"{p[0].strftime('%m/%d/%y')}-{p[1].strftime('%m/%d/%y')}"]
 
-		# ISO-based periodicity - labels created off the start date from each bin
+		# ISO-based periodicity
 		elif periodicity == "ISO Week":
 			# Returns format: "Week N-YY"
 			return [f"Week {iso_w}-{str(iso_y)[-2:]}" for iso_w, iso_y in iso_data]
 		elif periodicity == "ISO Biweekly":
 			# Returns format: "Weeks N-N YY"
 			return [
-				f"Weeks {bin[0].isocalendar().week}-{bin[1].isocalendar().week} {str(bin[1].isocalendar().year)[-2:]}"
-				for bin in bins
+				f"Weeks {p[0].isocalendar().week}-{p[1].isocalendar().week} {str(p[date_idx].isocalendar().year)[-2:]}"
+				for p in bins
 			]
 		elif periodicity == "ISO Annual":
 			# Returns format: "YYYY"
@@ -788,16 +817,24 @@ class Period:
 			# Returns format: "MMM (Nw)-YY", "QN-YY", or "HYN-YY" for month, quarter, or semiannual periodicity
 			return [f"{iso_buckets[iso_w][periodicity]}-{str(iso_y)[-2:]}" for iso_w, iso_y in iso_data]
 
-		# Calendar-based periodicity - labels created off the end date from each bin
+		# Fiscal Weeks
+		elif periodicity == "Fiscal Weeks":
+			# Returns format: "I (Nw)-YY"
+			return [
+				f"{i} ({int(((p[1] - p[0]).days + 1) / 7)}w)-{p[date_idx].strftime('%y')}"
+				for i, p in enumerate(bins, start=1)
+			]
+
+		# Calendar-based periodicity
 		elif periodicity in ["Calendar Month", "Monthly"]:
 			# Returns format: "MMM-YY"
-			return [p[1].strftime("%b-%y") for p in bins]
+			return [p[date_idx].strftime("%b-%y") for p in bins]
 		elif periodicity in ["Calendar Quarter", "Quarterly"]:
 			# Returns format: "MM-YYQ"
-			return [f"{p[1].strftime('%m-%y')}Q" for p in bins]
+			return [f"{p[date_idx].strftime('%m-%y')}Q" for p in bins]
 		else:  # periodicity in ("Custom Days", "Weekly", "Biweekly", "Calendar Year", "Annually")
 			# Returns format: "MM/DD/YY"
-			return [p[1].strftime("%m/%d/%y") for p in bins]
+			return [p[date_idx].strftime("%m/%d/%y") for p in bins]
 
 	def _get_iso_week_and_year(self, date: datetime.date) -> tuple[int, int]:
 		"""

--- a/tests/test_date_binning.py
+++ b/tests/test_date_binning.py
@@ -111,10 +111,6 @@ class TestBins:
 			Period().get_date_bins(date_dec_31_23, date_jan_2_23)
 
 	def test_custom_period_errors(self, date_jan_2_23, date_dec_31_23):
-		# No custom_period provided
-		with pytest.raises(ValueError):
-			Period().get_date_bins(date_jan_2_23, date_dec_31_23, "Custom Days")
-
 		# Provided custom_period not an integer or list
 		with pytest.raises(ValueError):
 			Period().get_date_bins(date_jan_2_23, date_dec_31_23, "Custom Days", custom_period=2.5)
@@ -421,6 +417,17 @@ class TestBins:
 		assert bins == output
 
 	# Calendar Period Tests
+	def test_custom_days_default(self, date_jan_1_23, date_jan_5_23):
+		output = [
+			(datetime.date(2023, 1, 1), datetime.date(2023, 1, 1)),
+			(datetime.date(2023, 1, 2), datetime.date(2023, 1, 2)),
+			(datetime.date(2023, 1, 3), datetime.date(2023, 1, 3)),
+			(datetime.date(2023, 1, 4), datetime.date(2023, 1, 4)),
+			(datetime.date(2023, 1, 5), datetime.date(2023, 1, 5)),
+		]
+		bins = Period().get_date_bins(date_jan_1_23, date_jan_5_23, "Custom Days", inclusive=True)
+		assert bins == output
+
 	def test_custom_days(self, date_mar_15_23, date_mar_31_23):
 		output = [
 			(datetime.date(2023, 3, 15), datetime.date(2023, 3, 19)),
@@ -444,6 +451,17 @@ class TestBins:
 		bins = Period().get_date_bins(
 			date_jan_2_23, ed, "Custom Days", inclusive=True, custom_period=[5, 2]
 		)
+		assert bins == output
+
+	def test_fiscal_weeks_default(self, date_jan_1_23):
+		ed = datetime.date(2023, 1, 28)
+		output = [
+			(datetime.date(2023, 1, 1), datetime.date(2023, 1, 7)),
+			(datetime.date(2023, 1, 8), datetime.date(2023, 1, 14)),
+			(datetime.date(2023, 1, 15), datetime.date(2023, 1, 21)),
+			(datetime.date(2023, 1, 22), datetime.date(2023, 1, 28)),
+		]
+		bins = Period().get_date_bins(date_jan_1_23, ed, "Fiscal Weeks", inclusive=True)
 		assert bins == output
 
 	def test_fiscal_weeks_454_monday(self, date_jan_2_23, date_dec_31_23):


### PR DESCRIPTION
Closes #32 

Adds a hybrid periodicity "Fiscal Weeks" to Period which respects the user's `start_date` (their week may start on any weekday) but groups weeks similar to the ISO patterns. The `get_date_bins` method's `custom_period` parameter takes either a value (like 13, to create 13-week quarterly bins), or a sequence that it cycles over (such as [4, 5, 4] to create monthly bins).

Example usage:

```py
import datetime
from forecast import Period

sd = datetime.date(2022, 12, 31)  # Saturday
ed = datetime.date(2023, 12, 29)

# 13 week quarters
bins = Period().get_date_bins(sd, ed, "Fiscal Weeks", inclusive=True, custom_period=13)
bins
[
    (datetime.date(2022, 12, 31), datetime.date(2023, 3, 31)),
    (datetime.date(2023, 4, 1), datetime.date(2023, 6, 30)),
    (datetime.date(2023, 7, 1), datetime.date(2023, 9, 29)),
    (datetime.date(2023, 9, 30), datetime.date(2023, 12, 29)),
]

# Months in 4-5-4 week pattern
bins = Period().get_date_bins(sd, ed, "Fiscal Weeks", inclusive=True, custom_period=[4, 5, 4])
bins
[
    (datetime.date(2022, 12, 31), datetime.date(2023, 1, 27))
    (datetime.date(2023, 1, 28), datetime.date(2023, 3, 3))
    (datetime.date(2023, 3, 4), datetime.date(2023, 3, 31))
    (datetime.date(2023, 4, 1), datetime.date(2023, 4, 28))
    (datetime.date(2023, 4, 29), datetime.date(2023, 6, 2))
    (datetime.date(2023, 6, 3), datetime.date(2023, 6, 30))
    (datetime.date(2023, 7, 1), datetime.date(2023, 7, 28))
    (datetime.date(2023, 7, 29), datetime.date(2023, 9, 1))
    (datetime.date(2023, 9, 2), datetime.date(2023, 9, 29))
    (datetime.date(2023, 9, 30), datetime.date(2023, 10, 27))
    (datetime.date(2023, 10, 28), datetime.date(2023, 12, 1))
    (datetime.date(2023, 12, 2), datetime.date(2023, 12, 29))
]
```

One caveat is noted in the docs - if the user wants a stub period (the use-case where they're 2 weeks into January, and want monthly bins still respecting the dates above), they can include the short period at the beginning of the sequence, but then must write out the rest so that value doesn't repeat. So the `custom_period` sequence would become `[2, 5, 4, 4, 5, 4, 4, 5, 4, 4, 5, 4]`.